### PR TITLE
Refine editorial positioning and homepage essay discovery

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,7 +1,7 @@
 # Marketing Context — BUT. Honestly
 
-**Document version:** v1
-**Last updated:** 2026-08-13
+**Document version:** v2
+**Last updated:** 2026-08-28
 
 > Context for skills that write or plan content for buthonestly.io. This is a personal
 > essay site, not a product: there is nothing to sell, no buying committee, and no sales
@@ -62,22 +62,17 @@ Never bend the *substance* to chase a term. Do sharpen the title, headings and e
 
 ## Who it's for
 
-**There is more than one reader, and they barely overlap.** The WooCommerce developer looking up an attribute filter and the lead reading about caring without feeling it are different people who arrive by different routes and rarely read each other's essays. Treat them as separate audiences rather than one blended persona.
+**The primary audience is people navigating leadership, work, and technology.** They come for honest accounts of what happened, what it cost, and what can be learned from it. They have usually shipped something, led people, or worked inside technical organisations; the writing is not expert-only, but it does not assume a first-timer.
 
-- **Practitioners** — people leading small technical teams or building for the web, who want the honest version with the tradeoffs named. The Leadership and Observations essays are for them.
-- **Searchers with a specific problem** — mostly WordPress and WooCommerce, arriving from Google for one answer. The Programming and Web archive serves them.
+WordPress and WooCommerce do not define this audience. Their 2015–2018 posts are a legacy archive that still attracts search traffic, not a meaningful influence on the site's direction. New essays may mention or focus on them from time to time when there is something worth saying, but they are no longer a primary editorial focus.
 
-**What follows:** an excerpt or title should be written for whichever audience that essay actually serves, not for a blended average. Cross-linking between the two groups is worth less than linking inside them, so do not force it.
+**Who arrives through the archive.** Search still finds pages such as `woocommerce_min_password_strength` (position 7.0) and `woocommerce attributes and variations` (14.5). Those visitors often need one specific answer. Their presence in analytics should not turn them into the assumed reader for new work.
 
-**Assumed level differs by audience.** For practitioners: you have shipped something. Not expert-only, but not a first-timer's guide. For searchers: they arrive knowing only their problem, and the older WooCommerce tutorials are written accordingly — genuinely beginner-level, which is a legacy of when they were written rather than a change in target.
-
-**Who arrives instead.** Search overwhelmingly finds the 2015–2018 WooCommerce archive: `woocommerce_min_password_strength` (position 7.0), `woocommerce attributes and variations` (14.5), plus software-licensing queries (9–12).
-
-**Leave it correct and leave it alone.** In his words: *"I don't want traffic from WooCommerce posts. They are there and they can stay, but I don't want to be known for that only. I want to be known for the new content."*
+**Leave the archive correct without letting it set the agenda.**
 
 - **Do** keep it accurate — snippets that work, dates that are honest, links that resolve. It helps whoever lands there.
-- **Do not** spend optimisation effort on it. Every winnable ranking the site has sits in this archive, and winning more of them grows an audience that will not read anything else.
-- **Rarely extend it.** WordPress and WooCommerce essays will appear occasionally, not consistently.
+- **Do not** spend optimisation effort on it merely because it holds the site's easiest rankings.
+- **Do** write about WordPress or WooCommerce occasionally when the subject genuinely fits; do not treat either as a required content stream.
 
 **This is a deliberate refusal of the easiest traffic available, and it should be respected rather than re-litigated.** A future session will notice those positions and want to chase them. Don't.
 
@@ -128,7 +123,7 @@ Where search work does belong: the newer essays that are genuinely searchable, `
 | Topic | The tags. 14 in use. |
 | Cornerstone | An evergreen hub essay others link to. Six named. |
 | Evergreen / decaying / trend-pinned | Durability tiers applied when drafting. |
-| Legacy tail | The 2015–2018 WooCommerce archive: maintained, not extended. |
+| Legacy tail | The 2015–2018 WordPress and WooCommerce archive: maintained, but no longer a meaningful influence on the site's direction. |
 
 ## Where things stand
 
@@ -183,4 +178,5 @@ Worth revisiting around **October 2026**, when URL consolidation finishes and th
 
 *Newest first. One line per revision: what changed and why.*
 
+- v2 (2026-08-28) — Reframed the audience around leadership, work, and technology; clarified that WordPress and WooCommerce are a legacy archive, not the site's primary direction.
 - v1 (2026-08-13) — Initial context, built with the author from repo copy, the Style Guide, all 49 essays and 28 days of Search Console data.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,3 +194,13 @@ Consult these guides before working on related tasks:
 - [Adding or managing content](https://docs.astro.build/en/guides/content-collections/)
 - [Adding styles or using Tailwind](https://docs.astro.build/en/guides/styling/)
 - [Supporting multiple languages](https://docs.astro.build/en/guides/internationalization/)
+
+## Agent skills
+
+### Issue tracker
+
+Issues and specs are tracked in GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+This is a single-context repository. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,1 @@
 @AGENTS.md
-
-## Agent skills
-
-### Issue tracker
-
-Issues and specs are tracked in GitHub Issues. See `docs/agents/issue-tracker.md`.
-
-### Domain docs
-
-This is a single-context repository. See `docs/agents/domain.md`.

--- a/src/components/Highlight.astro
+++ b/src/components/Highlight.astro
@@ -21,16 +21,14 @@ const postDate = new Date(post.date).toLocaleString("default", {
   id="highlight"
   class="border-line mx-auto my-10 grid max-w-6xl grid-cols-1 items-center gap-16 border-y px-6 pt-8 pb-16 min-[820px]:grid-cols-[1.35fr_1fr] md:px-10"
 >
-  <a href={post.url} data-track="Homepage lead essay click" tabindex="-1">
-    <Picture
-      src={post.cover!}
-      alt={post.featuredImageAlt ?? ""}
-      widths={[580, 768, 960, 1160, 1376]}
-      sizes="(max-width: 820px) 100vw, 580px"
-      class="w-full"
-      priority
-    />
-  </a>
+  <Picture
+    src={post.cover!}
+    alt={post.featuredImageAlt ?? ""}
+    widths={[580, 768, 960, 1160, 1376]}
+    sizes="(max-width: 820px) 100vw, 580px"
+    class="w-full"
+    priority
+  />
   <div class="flex-col space-y-6">
     <div class="flex items-center gap-3">
       <span class="label">
@@ -39,22 +37,10 @@ const postDate = new Date(post.date).toLocaleString("default", {
       <Divider width={20} />
       <span class="meta">Lead essay</span>
     </div>
-    <h2>
-      <a href={post.url} data-track="Homepage lead essay click">
-        {post.title}
-      </a>
-    </h2>
+    <h2><a href={post.url}>{post.title}</a></h2>
     <p class="lead">{post.excerpt}</p>
     <p class="meta">
       {postDate} &middot; <ReadTime content={post.body} />
     </p>
-    <a
-      href={post.url}
-      data-track="Homepage lead essay click"
-      class="label inline-block"
-      aria-label={`Read ${post.title}`}
-    >
-      Read the latest essay →
-    </a>
   </div>
 </section>

--- a/src/components/Highlight.astro
+++ b/src/components/Highlight.astro
@@ -21,14 +21,16 @@ const postDate = new Date(post.date).toLocaleString("default", {
   id="highlight"
   class="border-line mx-auto my-10 grid max-w-6xl grid-cols-1 items-center gap-16 border-y px-6 pt-8 pb-16 min-[820px]:grid-cols-[1.35fr_1fr] md:px-10"
 >
-  <Picture
-    src={post.cover!}
-    alt={post.featuredImageAlt ?? ""}
-    widths={[580, 768, 960, 1160, 1376]}
-    sizes="(max-width: 820px) 100vw, 580px"
-    class="w-full"
-    priority
-  />
+  <a href={post.url} data-track="Homepage lead essay click" tabindex="-1">
+    <Picture
+      src={post.cover!}
+      alt={post.featuredImageAlt ?? ""}
+      widths={[580, 768, 960, 1160, 1376]}
+      sizes="(max-width: 820px) 100vw, 580px"
+      class="w-full"
+      priority
+    />
+  </a>
   <div class="flex-col space-y-6">
     <div class="flex items-center gap-3">
       <span class="label">
@@ -37,10 +39,22 @@ const postDate = new Date(post.date).toLocaleString("default", {
       <Divider width={20} />
       <span class="meta">Lead essay</span>
     </div>
-    <h2><a href={post.url}>{post.title}</a></h2>
+    <h2>
+      <a href={post.url} data-track="Homepage lead essay click">
+        {post.title}
+      </a>
+    </h2>
     <p class="lead">{post.excerpt}</p>
     <p class="meta">
       {postDate} &middot; <ReadTime content={post.body} />
     </p>
+    <a
+      href={post.url}
+      data-track="Homepage lead essay click"
+      class="label inline-block"
+      aria-label={`Read ${post.title}`}
+    >
+      Read the latest essay →
+    </a>
   </div>
 </section>

--- a/src/components/Highlight.astro
+++ b/src/components/Highlight.astro
@@ -2,6 +2,7 @@
 import Divider from "./Divider.astro";
 import Picture from "./Picture.astro";
 import ReadTime from "./ReadTime.astro";
+import TaxLinks from "./TaxLinks.astro";
 
 import { type Post } from "../types.ts";
 
@@ -21,23 +22,34 @@ const postDate = new Date(post.date).toLocaleString("default", {
   id="highlight"
   class="border-line mx-auto my-10 grid max-w-6xl grid-cols-1 items-center gap-16 border-y px-6 pt-8 pb-16 min-[820px]:grid-cols-[1.35fr_1fr] md:px-10"
 >
-  <Picture
-    src={post.cover!}
-    alt={post.featuredImageAlt ?? ""}
-    widths={[580, 768, 960, 1160, 1376]}
-    sizes="(max-width: 820px) 100vw, 580px"
-    class="w-full"
-    priority
-  />
+  <a
+    href={post.url}
+    data-track="Homepage lead essay click"
+    class="block"
+    aria-label={`Read ${post.title}`}
+  >
+    <Picture
+      src={post.cover!}
+      alt={post.featuredImageAlt ?? ""}
+      widths={[580, 768, 960, 1160, 1376]}
+      sizes="(max-width: 820px) 100vw, 580px"
+      class="w-full"
+      priority
+    />
+  </a>
   <div class="flex-col space-y-6">
     <div class="flex items-center gap-3">
       <span class="label">
-        {post.categories.join(", ")}
+        <TaxLinks names={post.categories} base="section" />
       </span>
       <Divider width={20} />
       <span class="meta">Lead essay</span>
     </div>
-    <h2><a href={post.url}>{post.title}</a></h2>
+    <h2>
+      <a href={post.url} data-track="Homepage lead essay click">
+        {post.title}
+      </a>
+    </h2>
     <p class="lead">{post.excerpt}</p>
     <p class="meta">
       {postDate} &middot; <ReadTime content={post.body} />

--- a/src/content/essays/gaming-made-me-better-leader/gaming-made-me-better-leader.mdx
+++ b/src/content/essays/gaming-made-me-better-leader/gaming-made-me-better-leader.mdx
@@ -1,12 +1,14 @@
 ---
 title: How Gaming Made Me a Better Leader
 date: 2025-10-23
-updated: 2026-05-20
+updated: 2026-08-28
 sticky: false
 cornerstone: true
-excerpt: Games taught me leadership as facilitation, turning failure, empathy, and shared stories into practical habits for real world teams.
+excerpt: "Running D&D campaigns and playing co-op games taught me leadership habits I now use at work: when to guide, listen, and let someone else lead."
 newsletterIntro: |-
-  Games taught me leadership as facilitation, turning failure, empathy, and shared stories into practical habits for real world teams.
+  I learned some of my most useful leadership habits while rolling dice, running from killers, and falling off platforms with a colleague.
+
+  This essay is about what games taught me about trust, communication, and giving other people room to lead.
 categories:
   - Leadership
 tags:
@@ -31,165 +33,136 @@ import chainedTogetherLead from "./chained-together-lead.jpg";
 
 <QuickSummary>
 
-- Years of gaming shaped my leadership more than courses, by making collaboration, trust, and decision making feel concrete and lived.
-- Dungeons & Dragons taught me to guide without controlling, share ownership of the story, and treat leadership as anchoring a group journey.
-- Baldur’s Gate 3 and Divinity: Original Sin 2 showed how every decision has consequences and how transparency builds trust even after mistakes.
-- Dead by Daylight highlighted real-time communication, reading unspoken signals, and trusting teammates to act without micromanagement.
-- Chained Together embodied shared pace and mutual support, where progress only sticks when everyone moves together and learns from failure.
-- Across all these games, the lasting lessons are empathy, adaptability, shared stories, and leadership as coordination rather than command.
+- Running Dungeons & Dragons taught me to prepare a direction without controlling the people who take it.
+- Baldur’s Gate 3 showed me that people can disagree with a decision and still trust the person who explains it.
+- Dead by Daylight made me pay attention to what teammates need before they say it.
+- Chained Together taught me to match another person’s pace instead of dragging them behind mine.
+- Games gave me a safe place to practise failure, trust, and handing over the lead.
 
 </QuickSummary>
 
-Can playing games actually make you a better leader?
+Can playing games make you a better leader?
 
-It might sound strange at first. When most people think of leadership, they imagine meetings, strategies, and deadlines, not dice rolls, co-op sessions, or horror chases. Yet over time, I’ve realized that the games I’ve played have shaped how I lead, collaborate, and communicate more than any course or management book ever could.
+I learned some of my most useful leadership habits while rolling dice, running from killers, and falling off platforms with a colleague. Courses and management books gave me names for those habits. Games made me practise them.
 
-Games like _Dungeons & Dragons_, _Baldur’s Gate 3_, _Divinity: Original Sin 2_, _Dead by Daylight_, _Chained Together_, and probably more games I can’t even remember have each, in their own way, taught me something about how people work together. How trust forms and how progress happens when goals are shared.
+I played _Dungeons & Dragons_, _Baldur’s Gate 3_, _Divinity: Original Sin 2_, _Dead by Daylight_, and _Chained Together_ with incomplete information and no guarantee that my plan would work. I had to listen, adapt, and trust someone else to act.
 
-This post is about those lessons and how the virtual worlds I’ve explored have made me a better lead in the real one.
+## Dungeons & Dragons: Guiding Without Controlling
 
-## Dungeons & Dragons: Leadership Through Shared Stories
-
-### Guiding Without Controlling
-
-If I had to pick one game that changed how I think about leadership, it would be _[Dungeons & Dragons](https://en.wikipedia.org/wiki/Dungeons_%26_Dragons)_.
+If I had to pick one game that changed how I lead, it would be _[Dungeons & Dragons](https://en.wikipedia.org/wiki/Dungeons_%26_Dragons)_.
 
 <Figure src={dungeonsAndDragons} alt={"Official Dungeons & Dragons artwork featuring Tiamat, the five-headed dragon queen, surrounded by fire."}>
   Image by Wizards of the Coast LLC
 </Figure>
 
-I’ve spent years playing and running campaigns. Sitting behind the screen as a Dungeon Master, you quickly learn that your job isn’t to control the story. It’s to build a world, guide your players through it, and keep them engaged in a journey that ultimately is theirs. The story may start with you, but it only comes alive when everyone contributes.
+I have spent years playing and running campaigns. As the Dungeon Master, I build the world, prepare the encounters, and give the players somewhere to start. Then they choose where the story goes.
 
-This isn’t just my experience. [A 2023 qualitative study](https://www.academia.edu/95264016/PERCEPTIONS_OF_SKILL_TRANSFERENCE_FROM_DUNGEONS_and_DRAGONS_TO_PERSONAL_SOCIAL_AND_WORK_LIFE) by researcher C. N. Mackey found that players often transfer skills from Dungeons & Dragons into real-world contexts, particularly communication, delegation, and leadership in collaborative environments. I’ve seen the same thing firsthand: running a campaign demands many of the same instincts I rely on when leading a team.
+A DM who controls each scene drains the fun from the table. Players stop taking risks because they can tell their choices will not change anything. I have seen teams withdraw for the same reason. If I make each decision before they enter the room, I cannot expect them to feel ownership of the result.
 
-A DM who dominates every session quickly loses the group’s enthusiasm. Players stop making bold choices. The energy fades. It’s the same in a team: when people feel that every decision is already made for them, they disengage. Real leadership is about building a framework where others can shine, not about deciding everything yourself.
+[A 2023 qualitative study](https://www.academia.edu/95264016/PERCEPTIONS_OF_SKILL_TRANSFERENCE_FROM_DUNGEONS_and_DRAGONS_TO_PERSONAL_SOCIAL_AND_WORK_LIFE) by researcher C. N. Mackey found that players carry communication, delegation, and leadership skills from D&D into work and social settings. I recognise that transfer in my own work. Running a campaign has trained me to prepare enough structure for people to act without scripting what they do.
 
 <Figure src={sevenDoors} alt={"Seven closed doors in a black and white ornate hallway symbolizing opportunities and decisions."}>
   Photo by [Pixabay](https://www.pexels.com/@pixabay/) on [Pexels.com](https://www.pexels.com/)
 </Figure>
 
-D&D also taught me that planning only gets you so far. You can spend hours preparing a session, designing encounters, and imagining outcomes, and the players will still do something completely unexpected. Sometimes that chaos is frustrating, but more often, it’s inspiring. It forces you to adapt, to listen, and to say “_yes, and_” instead of “_no, but_”.
+Preparation still matters. I can spend hours designing a session, and the players can undo it with one choice I did not expect. The first few times this happened, I found it frustrating. Now I treat the plan as material I can use rather than a route everyone must follow.
 
-That ability to improvise, to embrace change instead of resisting it, is the same mindset I use when projects shift direction or unexpected problems appear.
+I use the same approach when a project changes direction. I keep the goal in view, listen to what the team has found, and adapt the route.
 
-### Building Trust and Ownership
+### Fair Rules Leave Room for Judgment
 
-Another lesson from the DM’s chair is the balance between fairness and flexibility. As a leader, you set the rules, but you also interpret them. You decide when to enforce structure and when to make exceptions for the sake of creativity or morale. Finding that balance takes empathy and judgment. In D&D, that means knowing when to let a player’s creative idea bend the rules. At work, it means understanding when a process should serve the people, not the other way around.
+A DM sets the rules and decides how to apply them. Sometimes the rules protect the group. Sometimes a player has an idea worth bending one for.
 
-And finally, D&D taught me about ownership. Players commit more deeply to a campaign when they help shape it. The same applies to teams. When people have real influence over decisions, their engagement skyrockets. As a DM, you learn that a player’s wild idea might lead to the most memorable part of the story. As a lead, I’ve seen that the best outcomes often come from empowering others to take risks and explore their own ideas.
+I make the same judgment at work. A process can keep work fair and clear, but it can also get in someone’s way. I need to know why the process exists before I decide whether this moment needs an exception.
 
-If I think about it, being a Dungeon Master isn’t about being in charge. It’s about being the anchor of a shared story. And that, to me, is the essence of leadership.
+Players also commit more to a campaign when their choices shape it. My teams have done the same. Some of our best work has started with an idea I would not have chosen on my own.
 
-Over the years, those D&D sessions helped me define what kind of leader I want to be. My approach has become my personal commitment to my team:
+Years behind the screen led me to write a commitment to my team:
 
 > _I commit to calm, open, and honest leadership that empowers through coaching and creativity._
 
-It’s a reminder that leadership isn’t about directing others, it’s about creating the right space for them to thrive.
+I use it to remind myself that I am there to give people enough support to do work they own.
 
-## Baldur’s Gate 3 and Divinity: Original Sin 2: Decisions That Matter
+## Baldur’s Gate 3: Explaining the Choice
 
-The modern RPGs from Larian Studios take the lessons of D&D and translate them into digital form. In _[Baldur’s Gate 3](https://baldursgate3.game/)_ and _[Divinity: Original Sin 2](https://store.steampowered.com/app/435150/Divinity_Original_Sin_2__Definitive_Edition/)_, every choice has weight. Your words change relationships, your actions shift outcomes, and sometimes even your silence speaks volumes.
+_[Baldur’s Gate 3](https://baldursgate3.game/)_ and _[Divinity: Original Sin 2](https://store.steampowered.com/app/435150/Divinity_Original_Sin_2__Definitive_Edition/)_ rarely label one decision as correct. Your words change relationships, your actions close routes, and your companions remember what you did.
 
-<Figure src={bg3} alt={"Baldur's Gate 3 Underdark Team in Act 2"}>
+<Figure src={bg3} alt={"Four adventurers walk among giant glowing mushrooms in the Underdark in Baldur’s Gate 3."}>
   Image by Larian Studios
 </Figure>
 
-These games don’t tell you what the “right” choice is. They simply present the consequences and let you live with them. That mirrors leadership more than most people realize.
+[A 2024 review](https://www.researchgate.net/publication/377628661_Video_Games_as_a_Way_to_Facilitate_Leadership_Skills_and_Competency_Development) by Hao and colleagues links decision-heavy games with situational awareness, accountability, and adaptive thinking. Larian’s games make me work through all three. I choose with limited information, watch the consequences, and decide what to do next.
 
-Research backs this up. [A 2024 review](https://www.researchgate.net/publication/377628661_Video_Games_as_a_Way_to_Facilitate_Leadership_Skills_and_Competency_Development) by Hao and colleagues found that decision-heavy video games encourage the same leadership behaviors we value in professional settings, like situational awareness, accountability, and adaptive thinking. Games like _Baldur’s Gate 3_ make those lessons tangible through narrative choice and consequence.
+Work gives me the same problem with higher stakes. I can make a sound decision and still meet resistance. I can also make a poor one and recover some trust by owning it. My team needs to know why I chose a direction and what I will do if it goes wrong.
 
-In any project or team, decisions ripple outward. Sometimes you make the right call and still face resistance. Other times you make a mistake, but the honesty with which you handle it builds more trust than perfection ever could. What matters most isn’t avoiding errors, but owning them and communicating openly about why you made a choice—a lesson I applied outside of leadership as well when I decided to switch to Jetpack Newsletter or WordPress.com as my hosting.
+My party members challenge me. They bring their own values and may reject mine. Their disagreement does not stop the group from moving, as long as the group has enough [trust to keep talking](/psychological-safety-in-teams-people-first-leadership/).
 
-Playing these games reminded me that alignment isn’t the same as agreement. Party members often challenge you, question your decisions, and bring their own perspectives. That tension doesn’t mean failure; it’s part of progress. The best teams, like the best adventuring parties, thrive when everyone feels safe to voice their perspective and challenge ideas without fear.
+I used to treat alignment as agreement. Now I see alignment as knowing the choice, the reason behind it, and what each person needs to do next. Someone can understand all three and still think I was wrong.
 
-Larian’s games reward clarity and consistency. Even companions who disagree with your methods respect you more when they understand your reasoning. The same is true in real leadership. If your team knows why you’re making a decision, they can adapt to it, even if they wouldn’t have chosen the same path.
+## Dead by Daylight: Reading the Team
 
-That’s one of the most powerful leadership lessons games can teach: people don’t need constant agreement, they need honesty and intent.
+I play _[Dead by Daylight](https://deadbydaylight.com/)_ solo and in SWF (_Survive With Friends_) mode with a colleague. The two versions ask me to communicate in different ways.
 
-## Dead by Daylight: Communication and Trust in the Moment
+As a solo survivor, I have no voice chat. I watch where another player runs, how long they hide, and whether they head towards a hooked teammate. I have to infer what they intend to do and cover the gap they leave.
 
-I play _[Dead by Daylight](https://deadbydaylight.com/)_ both solo and in SWF (_Survive With Friends_) mode with one of my colleagues. The difference between those two experiences is massive, and both have something to teach about leadership and collaboration.
-
-When I play solo, either as a survivor or killer, I have to read other players purely through in-game cues. Every action tells a story: someone running toward a hook, someone hiding too long, someone looping the killer to buy time. Without voice chat, teamwork depends on awareness and empathy. You learn to read intent and anticipate others’ moves. That has helped me in real projects, too, where you often have to sense what’s happening in your team even when no one says it out loud.
-
-<Figure src={deadByDaylightKiller} alt={"Michael Mayers from Dead by Daylight carrying a survivor."}>
+<Figure src={deadByDaylightKiller} alt={"Michael Myers from Dead by Daylight carrying a survivor."}>
   Image by Behaviour Interactive
 </Figure>
 
-But when I play SWF with my colleague, everything changes. We jump on a Discord call, plan strategies, and coordinate in real time. What stands out isn’t how we talk, but how we listen. Good communication in _Dead by Daylight_ isn’t about giving constant instructions; it’s about sharing the right information at the right time, and trusting that the other person knows what to do with it.
+Teams at work also tell me things before anyone says them aloud. A person who has gone quiet in meetings may need time, context, or help. I cannot know which from silence alone, but I can notice the change and ask.
 
-Sometimes one of us takes the lead in a chase while the other quietly focuses on objectives. Sometimes we switch roles mid-match without even saying a word because we both recognize what the moment requires. That silent understanding is the kind of rhythm I strive for in my team at work.
+In SWF, my colleague and I join a Discord call. We share the few details the other person needs: where the killer is, which generator is close, or who should make the rescue. We do not narrate each move. We trust each other to use the information.
 
-Interestingly, this aligns with what researchers have found in team-based gaming. [A 2021 study](https://pmc.ncbi.nlm.nih.gov/articles/PMC8715357/) by Michael J. Keith and his colleagues showed that playing multiplayer video games together significantly improves communication and trust between coworkers. That’s exactly what I experience when coordinating with my colleague in _Dead by Daylight_: it’s team-building in real time, just with higher stakes and more screaming.
+A [2021 study](https://pmc.ncbi.nlm.nih.gov/articles/PMC8715357/) by Michael J. Keith and his colleagues found that coworkers who played multiplayer games together improved their communication and trust. I have felt that change with my colleague. After enough matches, one of us can take a chase while the other works on the objective without negotiating the roles.
 
-The best collaboration happens when people feel trusted to make decisions on their own. _Dead by Daylight_ taught me that communication isn’t about control, it’s about connection. You don’t need to dictate every move; you just need to make sure everyone sees the same picture.
+I want the same balance at work. I share enough context for someone to decide, then let them decide.
 
-It’s also a great reminder that trust builds over time. The more we’ve played together, the more natural our coordination has become. That’s precisely how trust forms in teams: through shared experiences, small wins, and the comfort of knowing someone will cover for you when things go wrong.
+## Chained Together: Matching Someone Else’s Pace
 
-## Chained Together: Progress Happens at the Same Pace
-
-I discovered _[Chained Together](https://store.steampowered.com/app/2567870/Chained_Together/)_ recently. The premise is simple: two or more players are physically chained together and must climb through increasingly difficult levels. If one person falls, the other feels it immediately, and possibly falls with them.
+_[Chained Together](https://store.steampowered.com/app/2567870/Chained_Together/)_ connects two or more players with a chain and asks them to climb. If one person jumps too soon, both can fall.
 
 <Figure src={chainedTogetherTeam} alt={"Chained Together players looking forward"}>
   Image by Anegar Games
 </Figure>
 
-I’ve been playing it with the same colleague I play _Dead by Daylight_ with, and it’s been a surprisingly deep experience. Every jump, pull, and movement requires coordination. Sometimes I lead the climb, sometimes he does. When one of us moves too fast, we both fall.
+I play it with the same colleague. Every jump requires us to read each other’s timing. I lead some sections and follow through others. If either of us decides that his own pace is the right one, we end up back at the bottom.
 
-What makes the game interesting is how much it rewards patience and rhythm. You have to learn each other’s timing, trust your partner’s instincts, and stay calm under pressure. It’s not about perfection, it’s about progress together.
-
-That mirrors leadership perfectly. Teams don’t succeed when everyone works at their own speed; they succeed when the group finds a shared pace.
-
-Even workplace research supports this idea. [Atlassian’s own internal study](https://www.atlassian.com/blog/teamwork/video-games-can-help-your-team-work-smarter-no-seriously) found that teams who play cooperative games together improved their coordination and problem-solving by around twenty percent. In _Chained Together_, you can feel that same principle in action: progress only happens when everyone moves together.
-
-Pushing too hard can burn people out, moving too slowly can frustrate them. The challenge is to stay connected, to sense when to pull forward and when to let someone else take the lead.
+[A Brigham Young University study summarised by Atlassian](https://www.atlassian.com/blog/teamwork/video-games-can-help-your-team-work-smarter-no-seriously) found that new teams who played video games together for 45 minutes were about twenty percent more productive than teams who did other team-building exercises. _Chained Together_ gives that coordination a visible cost. The chain pulls tight when we stop paying attention to each other.
 
 <Figure src={chainedTogetherLead} alt={"Screenshot from Chained Together, lead going up a ladder"}>
   Image by Anegar Games
 </Figure>
 
-Some of the most valuable lessons from _Chained Together_ came not from winning, but from falling repeatedly and trying again. Those shared failures built trust faster than easy success ever could. The laughter, frustration, and persistence became part of the bond.
+I have made the same mistake with teams. Pushing at my pace can exhaust someone who needs more time. Holding everyone back can frustrate someone who is ready to move. I have to keep checking where people are and hand over the lead when they can see the next step better than I can.
 
-That’s something I carry into my work: shared struggle is powerful. When teams face challenges together, the sense of unity that comes afterward is real and lasting.
+The falls help too. Failing the same jump gives us a shared problem to solve without anyone needing to defend a performance review or a deadline. We laugh, change the timing, and try once more.
 
-## Lessons That Go Beyond the Games
+## The Habits I Took to Work
 
-After years of gaming, I’ve realized that the lessons I’ve learned from these worlds apply directly to leadership and teamwork.
+Games gave me a place to repeat a few leadership habits until I could recognise them at work.
 
-### Leadership is Coordination, Not Command
+### Give People a Direction They Can Change
 
-The best leaders act more like facilitators than dictators. They provide clarity, direction, and space for others to contribute. Whether it’s a D&D campaign or a project sprint, alignment beats authority every time.
+As a DM, I prepare the world and let the players alter it. At work, I set the goal, explain the constraints, and leave room for the team to find a route I missed.
 
-### Failure is Information
+### Treat Failure as Something to Examine
 
-In games, failure isn’t final. It’s feedback. You learn, adjust, and try again. The same mindset helps teams innovate. When mistakes are seen as data, not disasters, people take more initiative.
+A failed match gives you another attempt with more information. A team needs more care because work has consequences, but blame still hides the information I need. I want to know what we saw, what we assumed, and what we will change.
 
-### Empathy Drives Better Outcomes
+### Share Context, Then Stop Talking
 
-Every one of these games rewards empathy, whether it’s reading your teammate’s intentions in _Dead by Daylight_ or understanding your party’s motivations in _Baldur’s Gate 3_. Empathy turns leadership from management into connection.
+My colleague does not need a running commentary in _Dead by Daylight_. My team does not need one either. They need the facts I have, the decision I made, and the freedom to act on both.
 
-### Shared Stories Create Stronger Bonds
+### Let Someone Else Set the Pace
 
-Stories are how people make sense of experiences. D&D sessions, cooperative climbs, and close escapes all prove that shared challenges create lasting memories. The same is true for real teams. When people feel part of a collective story, motivation grows naturally.
-
-### Adaptability Beats Perfection
-
-No plan survives the dice, the killer, or the chaos of co-op play. Adaptability, not precision, is what keeps teams moving. Plans are useful, but flexibility is what wins.
+_Chained Together_ punishes me when I pull without looking back. Work may take longer to expose the same mistake. Regular check-ins help me notice it before someone burns out or gives up.
 
 ## From the Table to the Team
 
-What makes games such powerful teachers is that they’re safe spaces to explore how people interact. You can experiment, fail, adjust, and try again without real-world consequences. There are [games that teach real team skills](/team-building-activities-for-work/) through structured play — deliberately designed to build capabilities without relying on forced connection.
+Games let me practise these habits without risking a project or someone’s career. I can make a bad call, see what happened, and try a different one in the next session.
 
-Over time, you start recognizing the same patterns outside the screen.
+Some [games teach team skills](/team-building-activities-for-work/) through structured play. I learned more from playing for its own sake over many years. I noticed them while I was trying to keep a campaign moving, survive a chase, or get two chained characters over the same platform.
 
-When I lead a meeting today, I sometimes think like a Dungeon Master, making sure everyone gets a chance to speak and guiding the flow without forcing it. If decisions are hard, I remember that _Baldur’s Gate 3_ lesson: be transparent, own the choice, and move forward. When pressure rises, I think back to those voice calls in _Dead by Daylight_, where quick, honest communication made all the difference.
+I still think about those moments at work. In a meeting, I borrow the DM’s habit of making room for each player. During a hard decision, I explain my reasoning and accept that someone may disagree. If the team starts moving at different speeds, I check the chain before I pull.
 
-And when progress feels uneven, I remember being chained to my teammate, learning to move at the same rhythm.
-
-These experiences might seem unrelated to leadership, but they’ve shaped how I approach it every day.
-
-## Leadership Is Still a Team Sport
-
-In the end, gaming didn’t just make me a better player, it made me a better listener, communicator, and collaborator. Each game taught me something about guiding people, balancing structure with freedom, and building trust through shared challenges.
-
-Leadership isn’t about being the hero of the story. It’s about helping others become heroes in theirs.
+Gaming made me a better leader because it made collaboration concrete. I could see when I took too much control, feel when communication failed, and learn when someone else needed to lead.

--- a/src/content/essays/how-to-choose-a-software-license-for-your-next-project/how-to-choose-a-software-license-for-your-next-project.mdx
+++ b/src/content/essays/how-to-choose-a-software-license-for-your-next-project/how-to-choose-a-software-license-for-your-next-project.mdx
@@ -1,12 +1,14 @@
 ---
 title: How to Choose a Software License for Your Next Project
 date: 2026-05-05
-updated: 2026-05-23
+updated: 2026-08-28
 sticky: true
 cornerstone: true
-excerpt: Push code to GitHub with no license file and it isn’t really open source — just visible. By default nobody can legally use it, fork it, or fix your bug.
+excerpt: Without a software license, GitHub code stays copyrighted by default. People can see it, but may not have permission to use, fork, or fix it.
 newsletterIntro: |-
-  Push code to GitHub with no license file and it isn’t really open source — just visible. By default nobody can legally use it, fork it, or fix your bug.
+  A public GitHub repository is not open source unless its owner grants permission through a license.
+
+  This guide helps you choose that license, add it to a project, and avoid the mistakes that make your intentions hard to understand.
 categories:
   - Programming
 tags:
@@ -24,260 +26,185 @@ import softwareLicenseViolations from "./software-license-violations.jpg";
 
 <QuickSummary>
 
-- Without an explicit license, your code is **“all rights reserved”** and others can’t legally use, modify, or share it.
-- A software license is how you **give people permission** to use your work under specific conditions. Before choosing a license, decide your goals: **maximum adoption**, **guaranteed openness (copyleft)**, or **keeping parts proprietary**.
-- **Permissive licenses** (e.g. MIT, BSD, Apache 2.0) allow broad reuse, including in closed-source/commercial software.
-- **Copyleft licenses** (e.g. GPL) require derivative works to **remain open source** under the same or compatible license.
-- Always include a clear **LICENSE file**, update copyright notices, and mention the license in your **README** and project metadata.
-- Mixing licensed code has rules: you must **check compatibility** between your chosen license and any dependencies.
-- You can change or relicense your project later, but this gets harder once **outside contributors** are involved.
+- Publishing source code without a license leaves it under copyright by default. Other people can view it but may not have permission to use, modify, or share it.
+- Permissive licenses such as MIT, BSD, and Apache 2.0 allow broad reuse, including in proprietary software.
+- Copyleft licenses such as the GPL require people who distribute covered derivative work to provide it under the required open-source terms.
+- Creative Commons licenses suit writing, images, and other creative work rather than software code.
+- Add the full license text to a `LICENSE` file and declare the same license in your README and package metadata.
+- Check the licenses of your dependencies before distributing your project.
+- Relicensing becomes harder after other people contribute.
 
 </QuickSummary>
 
-Choosing a software license can feel like a legal maze, but it’s one of the most important decisions you’ll make for your software.
+Push code to a public GitHub repository without a license and people can see it. That does not make it open source.
 
-Developers often treat licenses as an afterthought. You finish building something, push it to GitHub, and move on. But if your repository doesn’t include a license file, you’re not technically “open source.”
+Copyright applies by default. Without permission from you, another person may not have the right to copy, modify, or distribute the code. A `LICENSE` file tells them which uses you allow and what conditions they must follow.
 
-By default, _no license_ means **all rights reserved**. Others can’t legally reuse, modify, or distribute your code. Even if someone forks your project or fixes a bug, they’re in a legal gray zone.
-
-Licensing your software early prevents headaches later. It protects your intentions, defines what others can do with your code, and helps your project grow under clear rules.
-
-So here is how I pick one, whether the project is something I want shared or something I want kept.
+I choose a license before I invite anyone else to use or contribute to a project. The choice starts with what I want those people to be able to do.
 
 <Callout type="disclaimer">
 
-Everything shared in this essay reflects **my own opinions and experience**. I’m speaking solely on my behalf — **not on behalf of Automattic Inc.** or any of its brands.
+Everything shared in this essay reflects **my own opinions and experience**. I’m speaking solely on my behalf, **not on behalf of Automattic Inc.** or any of its brands.
 
-This essay provides **general educational information** about software licensing based on common practices in the open-source community. **It is not legal advice** and should not be relied upon as such. Software licensing involves complex legal considerations that vary by jurisdiction. Before making licensing decisions that could affect your legal rights or obligations, **consult a qualified attorney** specializing in intellectual property law.
+This essay provides **general educational information**, not legal advice. Software licensing rules and their effects vary with the code, the way you distribute it, and the jurisdiction. Consult a qualified intellectual-property lawyer when a decision could affect your rights or obligations.
 
 </Callout>
 
-## What a Software License Really Does
+## Start With the Permission You Want to Give
 
-A software license is a legal framework that answers three questions:
+When I choose a software license, I need answers to three questions:
 
-1.  Who can use your code?
-2.  What can they do with it?
-3.  Under what conditions?
+1. Who may use the code?
+2. What may they do with it?
+3. Which conditions must they follow?
 
-If you share your code publicly, a license is how you control the answers.
+Most open-source choices fall into two broad groups.
 
-Not all open source is the same. Some licenses encourage maximum freedom, while others enforce openness. That’s where the two broad categories come in: **permissive** and **copyleft**.
+**Permissive licenses** let people reuse the code with few conditions. They can often include it in proprietary and commercial software as long as they preserve the required notices.
 
-**Permissive licenses** (like MIT or Apache 2.0) let others do almost anything as long as they give credit. **Copyleft licenses** (like GPL) generally allow reuse only if derivative works also stay open-source
+**Copyleft licenses** require people who distribute covered derivative work to provide it under the same or compatible open-source terms. The exact obligation depends on the license and how the software is combined and distributed.
 
-The choice defines your project’s DNA — whether it spreads freely or ensures that openness stays intact downstream.
+I use this distinction to ask a practical question: do I care more about broad adoption, or about keeping distributed derivatives open?
 
-## The Most Common Open-Source Licenses
+## Common Open-Source Licenses
 
 ### MIT License
 
-The [MIT license](https://tlo.mit.edu/understand-ip/exploring-mit-open-source-license-comprehensive-guide) is short, simple, and extremely permissive. It lets anyone reuse, modify, and even sell your code, as long as they include your original copyright and license notice.
+The [MIT License](https://tlo.mit.edu/understand-ip/exploring-mit-open-source-license-comprehensive-guide) lets people use, copy, modify, distribute, sublicense, and sell the software. They must keep the copyright and license notice.
 
-It’s ideal if your main goal is _adoption_. You’re saying, “Use it however you want, just give me credit.”  
-That’s why MIT dominates GitHub, from React to small npm packages. As AI-powered tools like ChatGPT generate more code, understanding these licenses becomes even more critical for developers navigating both human-written and AI-generated contributions.
+I consider MIT when I want a small library or educational project to spread with little friction.
 
-**Best for:** small libraries, educational projects, or anything meant to spread widely with minimal friction.
+**I’d use it for:** projects where broad reuse matters more than keeping derivatives open.
 
-### GNU General Public License (GPL)
+### GNU General Public License
 
-The [GPL](https://www.gnu.org/licenses/licenses.html) protects _user freedom_ by requiring anyone who redistributes your code, modified or not, to do so under the same license.
+The [GNU General Public License](https://www.gnu.org/licenses/licenses.html) gives people permission to use, study, modify, and share covered software. If they distribute covered derivative work, the GPL requires them to provide the corresponding source under its terms.
 
-This “copyleft” clause keeps your work and its derivatives open-source forever. But it also means you can’t include GPL code in a closed-source product.
+WordPress and the Linux kernel use GPL-family licenses under different version terms. The details can become complex when GPL code interacts with other code, so I check compatibility before combining or distributing it.
 
-WordPress, Linux, and thousands of other projects rely on GPL to guarantee that improvements remain free and accessible.
-
-**Best for:** projects where openness matters more than commercial flexibility.
+**I’d use it for:** projects whose authors want distributed derivatives to remain open.
 
 ### Apache License 2.0
 
-[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) is permissive like MIT but adds **patent protection**.
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) is permissive and includes an explicit patent grant from contributors. It also contains a patent-termination clause for certain patent claims.
 
-If someone contributes code to your project and later tries to sue you over a patent related to that contribution, the Apache license invalidates their claim.
+I consider it when patent terms matter or when a company needs a familiar permissive license with more detail than MIT.
 
-This matters more now that people build with AI. When you [vibe code](/what-is-vibe-coding-how-to-do-it/), who wrote which line gets harder to answer.
-
-**Best for:** large or corporate-backed projects, or if you want explicit legal protection.
+**I’d use it for:** larger libraries, company-backed projects, and projects that want explicit patent terms.
 
 ### BSD Licenses
 
-[BSD licenses](https://en.wikipedia.org/wiki/BSD_licenses) (2-Clause and 3-Clause) are functionally similar to MIT. The 3-Clause adds a “no endorsement” rule, preventing people from using your name to promote derivative products.
+The [2-Clause and 3-Clause BSD licenses](https://en.wikipedia.org/wiki/BSD_licenses) resemble MIT. The 3-Clause version adds a condition preventing contributors’ names from being used to endorse derived products without permission.
 
-**Best for:** low-level software, libraries, or academic projects.
+**I’d use it for:** projects that want short, permissive terms. The 3-Clause version also addresses endorsement.
 
-### Creative Commons (CC) Licenses
+### Creative Commons Licenses
 
-[Creative Commons licenses](https://creativecommons.org/cc-licenses) are not for code, they’re for **content**: documentation, tutorials, UI assets, icons, videos, etc.
+[Creative Commons licenses](https://creativecommons.org/cc-licenses) are designed for creative works such as writing, documentation, images, and videos. Creative Commons recommends using established software licenses for software code.
 
-- **CC-BY:** reuse allowed with attribution.
-- **CC-BY-SA:** same as above, but derivatives must use the same license (like GPL).
-- **CC-BY-NC-SA:** same as above, but the content cannot be used for commercial purposes.
-- **CC0:** public domain dedication — no attribution required.
+Common options include:
 
-**Best for:** non-code assets that accompany software.
+- **CC BY:** allows reuse with attribution.
+- **CC BY-SA:** requires attribution and the same license for adaptations.
+- **CC BY-NC-SA:** adds a non-commercial restriction.
+- **CC0:** waives rights to the extent the law allows so others can reuse the work without attribution.
 
-### License Comparison at a Glance
+**I’d use it for:** documentation, tutorials, artwork, and other non-code material.
 
-| License              | Modify | Redistribute | Commercial Use | Require Attribution | Must Share Derivatives | Patent Protection |
-| -------------------- | ------ | ------------ | -------------- | ------------------- | ---------------------- | ----------------- |
-| **MIT**              | ✅     | ✅           | ✅             | ✅                  | ❌                     | ❌                |
-| **GPL**              | ✅     | ✅           | ✅             | ✅                  | ✅                     | ❌                |
-| **Apache 2.0**       | ✅     | ✅           | ✅             | ✅                  | ❌                     | ✅                |
-| **BSD (2/3-Clause)** | ✅     | ✅           | ✅             | ✅                  | ❌                     | ❌                |
-| **CC-BY-SA**         | ✅     | ✅           | ✅             | ✅                  | ✅                     | ❌                |
-| **CC-BY-NC-SA**      | ✅     | ✅           | ❌             | ✅                  | ✅                     | ❌                |
-| **CC0**              | ✅     | ✅           | ✅             | ❌                  | ❌                     | ❌                |
+### License Comparison
 
-This table provides general guidance. Always review specific license terms in full.
+| License              | Modify | Redistribute | Commercial Use | Keep Notice | Share Covered Derivatives | Explicit Patent Grant |
+| -------------------- | ------ | ------------ | -------------- | ----------- | ------------------------- | --------------------- |
+| **MIT**              | ✅     | ✅           | ✅             | ✅          | ❌                        | ❌                    |
+| **GPL**              | ✅     | ✅           | ✅             | ✅          | ✅                        | ❌                    |
+| **Apache 2.0**       | ✅     | ✅           | ✅             | ✅          | ❌                        | ✅                    |
+| **BSD (2/3-Clause)** | ✅     | ✅           | ✅             | ✅          | ❌                        | ❌                    |
+| **CC BY-SA**         | ✅     | ✅           | ✅             | ✅          | ✅                        | ❌                    |
+| **CC BY-NC-SA**      | ✅     | ✅           | ❌             | ✅          | ✅                        | ❌                    |
+| **CC0**              | ✅     | ✅           | ✅             | ❌          | ❌                        | ❌                    |
 
-## What If You Don’t Want to Open Source It?
+This table leaves out details that can change the answer for a specific project. Read the license text before relying on a row.
 
-Not every project should be open-source. Internal tools, client work, or commercial software often need to stay private.
+## Keeping a Project Proprietary
 
-If your goal is to keep full control, you don’t need an open-source license at all. Simply **reserve all rights** with language such as this:
+You do not need an open-source license for internal tools, client work, or software you want to keep proprietary.
+
+An all-rights-reserved notice can make that intent clear:
 
 ```text
 Copyright © [Year] [Your Name or Company]
-All rights reserved. This software may not be used, copied, modified, or distributed without explicit permission.
+All rights reserved.
 ```
 
-If you distribute software (like a paid plugin or SaaS), use a custom [EULA (End User License Agreement)](https://en.wikipedia.org/wiki/End-user_license_agreement).  
-It defines what users _can do_ (install, use, modify internally) and _cannot do_ (resell, redistribute, reverse-engineer, etc.).
+If you distribute proprietary software, an [End User License Agreement](https://en.wikipedia.org/wiki/End-user_license_agreement) can define how customers may install and use it. A lawyer should draft or review terms that govern a commercial product.
 
-## How to Choose the Right Software License
+## How I Narrow the Choice
 
-You don’t need to memorize legal jargon. You need to know what you want the project to do. The steps to choose a license outlined below are a guideline for you to follow, although you might want to dig deeper based on your specific case.
+### 1. Decide what should happen to reused code
 
-### Step 1. Clarify your goals.
+I begin with the outcome:
 
-- Want your code to spread freely? → _MIT, Apache, BSD._
-- Want to ensure derivatives stay open? → _GPL._
-- Want to keep it private? → _All rights reserved or EULA._
-- Sharing creative assets? → _Creative Commons._
+- Broad reuse, including proprietary products: **MIT, Apache 2.0, or BSD**.
+- Distributed derivatives must remain open: **a GPL-family license**.
+- No public reuse permission: **all rights reserved or a proprietary agreement**.
+- Creative material rather than software: **a suitable Creative Commons license**.
 
-### Step 2. Check dependencies and libraries.
+The short list is a starting point, not a substitute for reading the terms.
 
-If your project uses third-party libraries, their licenses may _force_ your choice.
+### 2. Check every dependency
 
-**Example:**  
-If you bundle a GPL library, your project **typically must** also be GPL-compatible  
-MIT and Apache mix freely, but non-commercial CC assets can’t appear in paid WordPress themes.
+A dependency’s license may place conditions on how I distribute my project. I check direct dependencies, bundled assets, copied snippets, and generated code whose origin I can identify. That includes code I produce while [vibe coding](/what-is-vibe-coding-how-to-do-it/).
 
-### Step 3. Think about contributors and companies.
+Compatibility can depend on how two works interact and whether I distribute the result. I do not guess when the combination is unclear.
 
-If you expect contributions, use a familiar, trusted **open-source license**.  
-Companies usually prefer MIT or Apache because they’re clear and risk-free.
+### 3. Account for contributors
 
-### Step 4. Add a LICENSE file early.
+Relicensing code becomes harder after other people own copyright in their contributions. I choose a known license before accepting contributions and explain the terms in the contribution process.
 
-Even a placeholder helps. It signals clarity and avoids confusion later.
+Some projects use a [Contributor License Agreement](https://en.wikipedia.org/wiki/Contributor_license_agreement). Others rely on the inbound license of each contribution. Either approach needs to be clear before the first pull request.
 
-### Step 5. Take advantage of these resources and tools.
+### 4. Use a standard license
 
-- [choosealicense.com](https://choosealicense.com) — plain-English summaries.
-- [GitHub license picker](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository).
-- [SPDX License List](https://spdx.org/licenses/).
-- [TLDRLegal](https://tldrlegal.com) — readable license explanations.
+A standard license gives users terms they can recognise and compare. I avoid writing a custom license unless a lawyer and a specific business need justify it.
 
-### Step 6. Consult a lawyer. (optional)
+These tools help me review established options:
 
-If you deem it necessary and are unsure which license to choose, **consult a lawyer familiar with intellectual property and open-source licensing**.
+- [Choose a License](https://choosealicense.com) provides plain-language summaries.
+- [GitHub’s license picker](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) adds common licenses to a repository.
+- The [SPDX License List](https://spdx.org/licenses/) provides standard identifiers and license texts.
+- [TLDRLegal](https://tldrlegal.com) summarises common permissions and conditions.
 
-## Can You Change Your License Later?
+### 5. Ask a lawyer when the consequences justify it
 
-You can, but not retroactively. Once a version is released under a software license, it stays that way.  
-Future versions can use a new license, but old ones remain under the original terms.
+I would get legal advice before combining licenses I do not understand, relicensing code with several contributors, enforcing a license, or attaching custom terms to a commercial product.
 
-**Example:** Project is MIT until commit `abc123`, GPL after `def456`. Code before `abc123` stays MIT forever. Everything after is GPL.
+## Add the License to the Project
 
-If others have contributed, get their consent before relicensing. Large projects solve this with [Contributor License Agreements (CLAs)](https://en.wikipedia.org/wiki/Contributor_license_agreement).
+Choosing a license does not help users if they cannot find it.
 
-### What If You Used the Wrong License by Mistake?
+### Add the full text
 
-If you catch it early (and nobody cloned/forked your repo yet), fix it fast:
+I put the complete license text in a plain-text file named `LICENSE` or `LICENSE.txt` at the repository root. I fill in the holder and year when the official template includes those fields. Otherwise, I preserve the license text.
 
-```bash
-git commit --amend
-git push --force
-```
-
-If the repo was already public, deleting or rewriting history won’t remove the old license. Those copies remain valid.
-
-To correct it:
-
-1.  Commit the right license.
-2.  Add a README note explaining the fix.
-3.  Restart the project if it had low visibility.
-4.  Get legal advice if needed.
-
-Deleting your repository doesn’t delete the license others already received.
-
-## How to Properly Add a License to Your Project
-
-Picking a license is one thing, actually _applying_ it is another. If you don’t include it correctly, the license technically doesn’t exist.
-
-Here’s how to make sure your license is clear, valid, and visible everywhere it needs to be.
-
-### Step 1. Create a `LICENSE` file in your project root
-
-Every public repository or distributed project should include a plain-text file named exactly `LICENSE` or `LICENSE.txt`.
-
-That file should contain the **full text** of your chosen license, not just a reference or link.  
-You can copy it directly from [choosealicense.com](https://choosealicense.com), the SPDX database, or the official license source (like the [GNU site](https://www.gnu.org/licenses/)).
-
-**Example (for MIT):**  
-Copy the entire MIT license text, update your name and year, and place it at the root of your repo.
+For MIT, the file begins like this:
 
 ```text
 MIT License
 
-Copyright (c) 2025 Nicola Mustone
+Copyright (c) 2026 Nicola Mustone
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+in the Software without restriction...
 ```
 
-This makes it immediately visible to anyone viewing or downloading your project.
+I copy the text from the license steward, [Choose a License](https://choosealicense.com), or the SPDX list rather than recreating it from memory.
 
-### Step 2. Add a short header comment to your source files
+### Declare it in package metadata
 
-While the main license file is the official reference, it’s good practice to include a **short header comment** in your key files, especially if the project might be reused elsewhere.
+Package registries and dependency tools read the license from project metadata.
 
-At the top of major files (like `index.js`, `main.py`, or `plugin.php`), add something like:
-
-```javascript
-/*
- * Project: My Cool Library
- * License: MIT
- * Copyright © 2025 Nicola Mustone
- * See LICENSE file in the project root for full license text.
- */
-```
-
-This ensures that even if the file gets copied out of context, the license still travels with it. You don’t have to include this in every single file, just the core ones that might be reused individually.
-
-These header comments appear in every snippet I share, from e-commerce customizations like [disabling GTIN requirements](/disable-gtin-requirements-non-eligible-woocommerce-products/) to Python scripts. The headers travel with the code, ensuring proper attribution even when files are copied individually.
-
-### Step 3. Include license info in your package metadata (if applicable)
-
-If your project is published as a package or library, always declare the license in its metadata:
-
-**For npm (JavaScript)**:
+For npm:
 
 ```json
 {
@@ -286,13 +213,14 @@ If your project is published as a package or library, always declare the license
 }
 ```
 
-**For Python (setup.cfg or pyproject.toml)**:
+For Python, the current packaging specification supports SPDX expressions in `pyproject.toml`:
 
-```python
+```toml
+[project]
 license = "MIT"
 ```
 
-**For Composer (PHP)**:
+For Composer:
 
 ```json
 {
@@ -300,93 +228,56 @@ license = "MIT"
 }
 ```
 
-These declarations make your license machine-readable and visible in package directories and dependency scanners.
+I use the correct SPDX identifier and keep it consistent with the `LICENSE` file.
 
-### Step 4. Mention the license in your README
+### Mention it in the README
 
-Your README is the first thing people see, and many won’t check the LICENSE file.  
-Add a short line at the bottom, like:
-
-```text
-License: MIT © 2025 Nicola Mustone
-```
-
-If you’re dual-licensing (e.g., open-source and commercial), note that too:
+A short README line helps someone find the terms:
 
 ```text
-License: GPL-2.0-or-later for open use, or commercial license available upon request.
+Licensed under the MIT License. See LICENSE for details.
 ```
 
-This provides instant clarity without legal digging.
+Dual-licensed projects need to state the available choices and where each set of terms applies.
 
-### Step 5. Keep it consistent everywhere
+### Add notices where the license requires them
 
-Consistency builds trust. Your license file, headers, and metadata should all say the same thing: version, year, and type included.
+Some projects add a short license header to source files that may travel on their own. The right notice depends on the license and project. I do not paste a long template into every file without checking what the chosen license asks me to preserve.
 
-If you ever update your license (say from GPLv2 to GPLv3), change it everywhere in one go.
+## Changing a License Later
 
-## What to Do If Someone Violates Your License
+You can release future versions under a different license if you own the necessary rights. The new choice does not cancel permissions already granted for earlier releases.
 
-Even with the clearest license, infringements happen. Maybe someone copied your code without attribution, resold your GPL-licensed plugin without sharing the source, or used your assets in a way your license doesn’t allow.
+If other people contributed code, you may need their permission before relicensing their work. A contributor agreement may have granted the project enough rights, but the agreement itself controls that answer.
 
-Here’s how to handle it, calmly, methodically, and without burning bridges.
+I document a change in the repository and release notes so users can tell which versions use which terms.
+
+If I publish the wrong license and notice it at once, I still do not assume rewriting Git history solves the problem. Someone may already have received a copy under those terms. I correct the repository, record what changed, and get legal advice if the mistake has consequences.
+
+## If Someone Breaks the Terms
+
+I would begin by checking the license and documenting the suspected breach. A missing attribution notice, an unpublished source obligation, and unlicensed use raise different questions.
 
 <Figure src={softwareLicenseViolations} alt={"Black and white lithograph of diverse individuals, including a nun and a man using a magnifying glass, reading intensely at a library table."}>
-  Photo by [The New York Public Library](https://unsplash.com/@nypl?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
+  Image from [The New York Public Library](https://unsplash.com/@nypl?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
 </Figure>
 
-### Step 1. Confirm it’s really a violation.
+If the facts look clear, a private message may resolve the problem. I would include the project, the license term, and the action I want the other person to take.
 
-Start by checking the facts. Ask yourself:
+A formal takedown or legal claim carries risks. Before escalating, I would preserve emails, repository links, releases, and screenshots, then speak with a lawyer. For GPL projects, organisations such as the Free Software Foundation and Software Freedom Conservancy publish compliance guidance.
 
-- Did they actually breach a license term (like removing attribution or not sharing modifications)?
-- Is your license clearly included in your project and easy to find?
-- Could it be a misunderstanding rather than intentional misuse?
+I would ask them to comply rather than punish them.
 
-Many developers simply don’t realize what a license requires. If you’re unsure whether a situation counts as infringement, **consult a lawyer familiar with intellectual property and open-source licensing** before taking action. It’s the best way to protect yourself and avoid unnecessary conflict.
+## Choose Before You Publish
 
-### Step 2. Reach out privately first.
+The `LICENSE` file tells another developer whether they may use your work, which conditions follow it, and whether their own project can include it.
 
-If you’re confident there’s an issue, contact them directly and politely. Include:
+I choose before publishing, check my dependencies, and put the same answer in the license file and package metadata. That gives someone who wants to use the code a clear place to begin.
 
-- A link to your original project and license file.
-- A short explanation of what part of the license they’re violating.
-- What action you’d like them to take (for example, restore attribution, publish modified source, or remove unlicensed content).
+## The Licenses on This Site
 
-Keep your message factual and professional. Most people will comply once they understand the situation.
+When I [rebuilt this site from WordPress in Astro](/wordpress-to-astro/), I kept separate terms for its code and content.
 
-### Step 3. If they ignore you, escalate carefully.
+The essays and images I own on this site use **Creative Commons Attribution-NonCommercial-ShareAlike (CC BY-NC-SA)** unless a page says otherwise. You may share and adapt them for non-commercial purposes with attribution and the same license.
 
-If they don’t respond or refuse to resolve the issue:
-
-- **Consider filing** a DMCA takedown with the platform hosting the content (GitHub, npm, WordPress.org, etc.).
-- For GPL projects, organizations like the **Free Software Foundation** or **Software Freedom Conservancy** sometimes assist in enforcing compliance.
-- In serious or commercial cases, contact a lawyer to explore next steps.
-
-**Note:** Filing a DMCA takedown requires a good faith belief that infringement occurred, and false claims can have legal consequences.
-
-Document everything — emails, screenshots, repository links — before escalating. It makes any future action more straightforward.
-
-### Step 4. Focus on compliance, not punishment.
-
-The goal isn’t to “win” a dispute, it’s to bring your work back under the terms you set.  
-If the other party resolves the issue and respects your license going forward, treat that as success. Education and clarity usually go farther than confrontation.
-
-## Take a Moment to Choose a Software License
-
-Choosing a license isn’t about control — it’s about clarity. [Evaluating WordPress plugins and themes](/do-you-trust-your-instincts-making-smart-wordpress-choices/) requires the same judgment. A good license defines boundaries, protects your work, and shows professionalism.
-
-Whether you want your code to empower others or stay private, decide intentionally — not by omission.
-
-Next time you push a project live, take a moment for the license.  
-It’s the smallest file in your repo but often the most powerful one.
-
-## What About This Essay?
-
-I practice what I preach.
-
-The text and images in this article are licensed under **Creative Commons Attribution–ShareAlike–NonCommercial (CC BY-SA-NC)**. You can share, adapt, or remix it for non-commercial purposes. Just credit me and keep it under the same license.
-
-Any code (or piece of) on this website is licensed under **GNU GPL v2 (or later)**, so you can use and modify it in compatible projects, in the spirit of open source.
-
-Unless otherwise specified, this is the default license for all content published on _buthonestly.io/_.
+Code I publish here uses **GNU GPL v2 or later** unless I specify another license. Third-party images, quotations, and code remain under their respective terms.

--- a/src/content/essays/psychological-safety-in-teams-people-first-leadership/psychological-safety-in-teams-people-first-leadership.mdx
+++ b/src/content/essays/psychological-safety-in-teams-people-first-leadership/psychological-safety-in-teams-people-first-leadership.mdx
@@ -1,12 +1,14 @@
 ---
 title: Building Psychological Safety in Teams Through People-First Leadership
 date: 2025-10-01
-updated: 2026-08-19
+updated: 2026-08-28
 sticky: false
 cornerstone: true
-excerpt: "Psychological safety grows from people-first leadership: daily transparency, shared ownership, and empathy that help teams belong and thrive."
+excerpt: Psychological safety grew in my team when I explained decisions, admitted mistakes, and gave people a say in how we worked together.
 newsletterIntro: |-
-  Psychological safety grows from people-first leadership: daily transparency, shared ownership, and empathy that help teams belong and thrive.
+  My team did not learn to speak up because I told them it was safe. They learned through what happened after they disagreed, made a mistake, or asked for help.
+
+  This essay covers the habits that helped us build that trust through two restructures and several years of working together.
 categories:
   - Leadership
 tags:
@@ -29,159 +31,124 @@ import listenBeforeLeading from "./listen-before-leading.jpg";
 
 <QuickSummary>
 
-- Psychological safety is built through people-first leadership, where human connection and clarity come before metrics or authority.
-- Rebranding the team as Horizon and co-creating a handbook turned restructuring anxiety into shared identity, ownership, and belonging.
-- Everyday leadership practices like giving everyone space to speak, listening before deciding, and explaining “why” made trust tangible.
-- Admitting mistakes, co-creating growth goals, and supporting people even through termination showed accountability and empathy go both ways.
-- Informal bonds, shared tools like CliftonStrengths, and openness about ADHD turned differences into strengths and made safety self-sustaining through change.
-- Psychological safety proves to be a habit: asking instead of telling, explaining decisions, treating failure with empathy, and modeling transparency.
+- My team began building trust when everyone helped choose its name, values, and ways of working.
+- I make room for people to speak without forcing them to do it in public or on demand.
+- Explaining a decision matters as much as announcing it, especially when the decision came from someone above me.
+- I lost a team member’s trust by setting their goal for them. Giving ownership back changed how I handle growth conversations.
+- Sharing how my ADHD affects my work gives other people permission to tell me what they need.
 
 </QuickSummary>
 
-What makes people feel safe enough to speak up, disagree, or simply be themselves at work?
+What makes someone feel safe enough to disagree with their lead?
 
-It is easy to say, “We want an open culture,” but psychological safety does not come from slogans or handbooks. It grows through consistent behavior, especially from those who lead.
+I can tell a team that I want an open culture. They decide whether to believe me after they watch what I do with bad news, mistakes, and opinions I did not ask for.
 
-As a Happiness Lead (Customer Support Team Lead) at WordPress.com, I have learned that _people-first leadership_ is not a management style. It is a daily practice that shapes how teams communicate, collaborate, and trust each other. To me, it means putting human connection before performance metrics. When people feel respected, supported, and heard, great results follow naturally. It is about leading with empathy and clarity, not authority.
+I learned this as a Happiness Lead at WordPress.com. For me, people-first leadership meant explaining decisions in human terms and treating trust as part of the work. My team did not build that trust through one workshop or document. We built it through small choices we repeated for years, including how we handled two restructures.
 
-When I took over my first team, I did not just inherit responsibilities. I inherited people with stories, uncertainty, and a need for belonging. What happened next became one of the most defining experiences of my leadership journey.
+## Giving a New Team Something to Shape
 
-## Turning Change Into an Opportunity for Connection
+I joined WordPress.com in September 2022 and became the lead of a team called R2D2, named after [the Star Wars character](https://en.wikipedia.org/wiki/R2-D2). Soon after, an internal restructure brought people from another support team into ours.
 
-When I first joined WordPress.com in September 2022, I became the lead of a team called R2D2 (after [the robot from the Star Wars franchise](https://en.wikipedia.org/wiki/R2-D2)). Soon after, an internal restructuring brought new members from another support team into ours. None of us really knew what to expect. I was new as a lead; they were new to our way of working.
+I was new to leading. They were joining a group with its own history and habits. None of us knew what the new team would feel like.
 
-That mix of change and uncertainty could have gone badly. Instead, it became the perfect moment to start fresh.
+I proposed a new name, logo, and creed. I wanted the people joining us to help decide who we would become instead of asking them to fit an identity they had inherited.
 
-I proposed that we rebrand the team entirely: a new name, logo, and creed. The goal was not to make us look different but to help us feel like one team. I wanted everyone, including the new members, to have a say in who we were going to be and how we wanted to work together.
+Everyone submitted names and voted. After a few rounds, we chose **Horizon**. We drew logo ideas and commissioned a friend of mine to turn our sketches into the final version.
 
-Everyone proposed ideas, and we voted. After a few rounds of discussion, we chose the name **Horizon**. It symbolized openness, growth, and forward movement.
-
-We even designed a new logo together. None of us were designers, so we ended up commissioning a friend of mine to bring our sketches to life. But the process itself mattered far more than the result. Everyone participated. Everyone had ownership.
-
-<Figure src={horizonLogo} alt={"Team Horizon logo"}>
-  Horizon team logo. © All Rights Reserved
+<Figure src={horizonLogo} alt={"Dark blue HORIZON wordmark with an orange ring forming the second O."}>
+  Horizon team logo. © All Rights Reserved
 </Figure>
 
-That’s when I first saw how inclusion builds psychological safety. When people feel they can shape the team’s identity, they stop worrying about “fitting in” and start focusing on contributing.
+The logo itself mattered less than the process. Each person had changed the result. New and existing members began from the same place because nobody owned the old version of the team.
 
-## Defining Who We Were: The Horizon Handbook
+## Writing the Horizon Handbook Together
 
-A few months later, during our first in-person meetup in Seoul, South Korea, we took another step toward shaping our shared culture.
-
-Between workshops and skill-building games, we spent time getting to know each other as people. We laughed, shared experiences, and built connections that would carry us through challenges later on.
-
-Then, we built something that would stay with us for years: the **Horizon Handbook**.
+A few months later, we met in Seoul, South Korea. Between workshops and [skill-building games](/team-building-activities-for-work/), we wrote the **Horizon Handbook**.
 
 <Blockquote author="Team Horizon">
   We commit to unity, respect, and integrity, for a collaborative and diverse environment where every team member grows and excels, together.
 </Blockquote>
 
-It was not a list of rules. It was a living document that described who we were, how we worked, and how we treated each other. It included our locations, communication preferences, team values, and principles for collaboration.
+The handbook included our locations, communication preferences, values, and agreements about how we would work. We wrote it together rather than copying a set of company values into another document.
 
-Because we wrote it together, it reflected everyone’s voice. That co-creation turned abstract values into shared agreements. It showed that **psychological safety is not only about being able to speak up but also about agreeing on how we will treat each other when we do.**
+Writing the handbook together mattered when someone spoke up. We had already agreed on how we would treat disagreement, so the person did not have to guess whether the group could handle it.
 
-## Leading for Psychological Safety
+Timothy R. Clark describes four stages of psychological safety in _The 4 Stages of Psychological Safety_: inclusion, learning, contribution, and challenge. I can see that order in Horizon’s first years. People found a place in the team, learned together, took ownership, and became comfortable challenging an idea.
 
-Psychological safety in teams begins with leadership, but not in the way most people imagine. I’ve written more about [how unconventional experiences shaped my leadership mindset](/gaming-made-me-better-leader/). It does not mean protecting people from mistakes. It means creating an environment where mistakes, feedback, and disagreements are normal parts of growth.
+## The Habits That Built Psychological Safety
 
-Author Timothy R. Clark describes four stages of psychological safety: inclusion, learning, contribution, and challenge.[1](/) Looking back, I realized Horizon moved through those same stages naturally as we grew; from making everyone feel welcome to encouraging each other to challenge ideas with confidence.
+The handbook gave us a starting point. Our daily behaviour decided whether any of it was true.
 
-Here is how I approach it in my day-to-day leadership.
+### I Leave Room to Speak
 
-### Everyone Has a Voice, Without Pressure
+During team hangouts, I make space for each person to contribute. I do not force anyone to fill the silence.
 
-In team hangouts, I always make sure that everyone has the space to speak. But I never force it. Silence doesn’t mean disengagement. Occasionally it means reflection. People should know that their contributions are welcome but never mandatory.
+Silence can mean reflection, discomfort, distraction, or nothing at all. I cannot tell which by looking at a quiet square on a video call. I can make the invitation clear and follow up in a setting that suits the person better.
 
-Over time, that gentle respect turns into trust. When people speak, it’s because they genuinely want to, not because they feel obliged to.
+After enough meetings, people learn that I will listen when they speak and leave them alone when they need time.
 
-### Listening Before Leading
+### I Explain Decisions
 
-I listen to all opinions before making a decision, even when I already have one in mind. If I have to enforce something coming from higher up, I always explain _why_. It’s a small act of transparency that builds immense trust.
+I ask for opinions before I decide, including when I have a preference. I take the same approach when I [give someone feedback](/mastering-effective-feedback-facts-feelings-curiosity/): explain what I saw, listen to their view, then decide what comes next.
 
-People can handle hard news or directives if they understand the reasoning. What they struggle with is confusion and silence.
+If someone above me has made the decision, I share the reason and say which parts we can still influence.
+
+People can work with an answer they dislike. Unexplained decisions leave them guessing about the goal, the constraints, and whether their work mattered.
 
 <Figure src={listenBeforeLeading} alt={"Team leader gestures while speaking as colleagues listen around a table with laptops and tablets in a bright meeting room."} />
 
-### Transparency and Admitting Mistakes
+### I Say When I Was Wrong
 
-Transparency isn’t just about sharing information, it’s about sharing intent. I always tell my team how I’ll make decisions, how I’ll evaluate performance, and how I plan to use the information they share with me.
+I tell my team how I plan to evaluate performance and use the information they share. If I change that plan, I explain the change.
 
-And when I’m wrong, I say it plainly. No excuses, no deflection.
+I also say when I made a mistake. I do not need a long confession. I need to name what I did, acknowledge the effect, and explain what I will change. I want my team to see that accountability applies to me too.
 
-Admitting mistakes doesn’t weaken authority. It strengthens credibility. It indicates that accountability goes both ways; from leader to team and from team to leader. That’s what keeps safety alive.
+### I Let People Own Their Goals
 
-### Shared Ownership of Growth
+Early in my time as a lead, I set a growth goal for a team member. I believed it was the right goal for them, so I pushed ahead without giving them enough ownership.
 
-During one of my very first leadership experiences, I made the mistake of forcing a goal for a team member instead of with them. I genuinely believed it was the best goal for their growth at that moment. But as weeks passed, they struggled. Their motivation dropped, and their performance followed. Eventually, they told me that my approach was not working; they felt micromanaged and disconnected from their progress.
+Their motivation and performance dropped. After several weeks, they told me they felt micromanaged and disconnected from their progress.
 
-That was a humbling moment. I stepped back and gave them space to set their own pace and define what success looked like for them. Within weeks, everything changed. They found their rhythm, regained confidence, and ended up staying with the company for years.
+I stopped setting the pace for them. They chose what success would look like and how they wanted to reach it, while I helped with obstacles. They regained confidence and stayed with the company for years.
 
-Since then, one of my favorite moments in one-on-one meetings has been asking team members to define their own goals. I no longer set them for others. They are in the driver’s seat of their careers, and I am just there to help navigate.
+I still ask people to define their goals in one-on-one meetings. I can challenge, coach, and provide context, but the goal has to belong to the person doing the work.
 
-When people choose their own direction, they take ownership of their learning. When they know their leader trusts them to steer, they become more willing to experiment, fail, and grow.
+### I Keep Dignity in Hard Conversations
 
-### Empathy in Hard Moments
+Leadership includes disappointment and termination. In those conversations, I explain what happened without turning the person into the problem. We discuss what they can do next and what support I can offer.
 
-Leadership isn’t always celebration. Sometimes it’s about guiding people through disappointment, even termination.
+My team sees how I treat someone when things go wrong. If respect disappears with good performance, everyone learns that it had conditions.
 
-Whenever that happens, I make sure to support the person without judgment. We talk honestly about what happened, what could have gone differently, and how they can transition forward.
+## Informal Trust Still Counts
 
-The goal isn’t to soften reality; it’s to treat people with dignity. Because if safety only exists when things are going well, it’s not safety, it’s convenience.
+Horizon also had a WhatsApp group for music, memes, and personal updates. We kept work out of it.
 
-## Practicing Openness Every Day
+Those conversations helped us know one another outside tickets, goals, and performance. New members had an easy way to join the group without needing a formal team exercise.
 
-What made Horizon a safe team was not our new name or handbook. It was how we acted daily. We asked questions, [gave honest feedback](/mastering-effective-feedback-facts-feelings-curiosity/), and shared parts of our personal lives. Culture doesn’t live in handbooks or slogans; it lives in habits.
+In Seoul, we used the [CliftonStrengths assessment](https://www.gallup.com/cliftonstrengths/en/512510/cliftonstrengths-top-5-report.aspx) to discuss our talents and communication styles. The results gave us a shared vocabulary for differences we had felt but struggled to describe.
 
-Furthermore, we created a WhatsApp group, a small space to share music, memes, or personal updates. Anything but work. It may sound trivial, but those informal bonds are the glue of trust. It also helped newcomers to integrate with the rest of the team much faster than it would have normally taken.
+The WhatsApp group and CliftonStrengths gave us more chances to understand one another, which made later conversations easier.
 
-In Seoul, we also used the [CliftonStrengths assessment](https://www.gallup.com/cliftonstrengths/en/512510/cliftonstrengths-top-5-report.aspx) to understand one another’s natural talents and communication styles. It gave us language to discuss differences without judgment and helped us see how each person contributed uniquely to the team’s success.
+## Sharing How I Work
 
-The result? When new people joined Horizon later, they didn’t just adapt to the culture, they became part of it. Psychological safety had become self-sustaining.
+I have [combined-type ADHD](https://www.psychiatry.org/patients-families/adhd/what-is-adhd). My focus and response times vary. I can answer at once on one day and need a reminder on another. I can also sound more direct than someone expects.
 
-## Transparency as the Core of Trust
+I tell my team this because it affects them. They should not have to interpret a delayed reply as anger or a short message as disapproval.
 
-If there’s one leadership principle I now consider non-negotiable, it’s transparency.
+Sharing it also makes it easier for someone else to tell me how they work. I cannot support a need I do not know about, and they may not risk telling me until I have shown that differences are safe to discuss.
 
-As a leader, I don’t believe in surprises; not in expectations, performance evaluations, or strategic decisions. When I learn something that impacts me or my team, I tell them how I’ll use that information. When I make a choice, I explain the reasoning behind it.
+## Revising the Culture We Wrote
 
-That doesn’t mean I share everything, but I share _enough_ that nobody is left guessing.
+Horizon changed again in 2024. Another restructure reduced the team’s size, and we returned to the handbook during a meetup in Malaysia.
 
-<Blockquote author="My personal commitment">
-  I commit to calm, open, and honest leadership that empowers through coaching and creativity.
-</Blockquote>
+We shortened it. Some lines no longer described us, and others had become habits we did not need to spell out. Keeping the original wording for sentimental reasons would have made the document less honest.
 
-Transparency also means being open about your own process. I have [combined-type ADHD](https://www.psychiatry.org/patients-families/adhd/what-is-adhd), which sometimes makes my focus unpredictable or my communication patterns a bit unorthodox. I don’t hide that. Instead, I tell my team what that means for them; that I might respond quickly one day and slowly another, that I might need reminders for certain follow-ups, or that I might be more direct than they expect (one of the features that made me stand out as a leader).
+We rewrote the handbook without losing the respect behind it. We disagreed, rewrote old agreements, and kept treating one another with respect.
 
-That vulnerability actually helps others open up about their needs. It shows that psychological safety isn’t only about emotional comfort; it’s about practical understanding of how we work best together.
+## What I Learned About Psychological Safety
 
-## Evolving Together
+[Google’s Project Aristotle research](https://rework.withgoogle.com/intl/en/guides/understanding-team-effectiveness) identified psychological safety as the most important dynamic in its effective teams. Amy Edmondson, who developed the concept, defines it as [“a belief that the team is safe for interpersonal risk-taking”](https://web.mit.edu/curhan/www/docs/Articles/15341_Readings/Group_Performance/Edmondson%20Psychological%20safety.pdf).
 
-In 2024, the team changed again. We restructured, reduced in size, and revisited the **Horizon Handbook** during our meetup in Malaysia. We shortened it, updated what no longer reflected us, and removed what didn’t need to be said anymore.
+I saw that belief form through ordinary moments. A person challenged my decision. Someone admitted confusion before a mistake grew. I apologised and changed a goal I had imposed. The team saw how I responded and knew what to expect next time.
 
-That process mirrored our growth. We didn’t need to declare psychological safety; we were living it. Feedback flowed naturally. We disagreed, sometimes passionately, but always with respect. The culture evolved, but the foundation of trust, empathy, and openness stayed the same.
-
-## What I Learned About Psychological Safety in Teams
-
-Looking back, I realize that building psychological safety isn’t a project. It’s a habit, practiced through small, consistent actions:
-
-- Asking instead of telling.
-- Listening without rushing to reply.
-- Explaining decisions openly.
-- Admitting mistakes quickly.
-- Treating people with empathy, especially when they fail.
-
-Those are the moments that define whether people feel safe or cautious.
-
-In _Project Aristotle_, [Google’s research into high-performing team](https://rework.withgoogle.com/intl/en/guides/understanding-team-effectiveness)s, psychological safety ranked as the number one factor for success. Amy Edmondson, who pioneered [the concept](https://web.mit.edu/curhan/www/docs/Articles/15341_Readings/Group_Performance/Edmondson%20Psychological%20safety.pdf), describes it as _“a belief that the team is safe for interpersonal risk-taking.”_
-
-I have observed that truth firsthand. When people trust that they can speak freely, question decisions, or admit confusion without fear, that is when true collaboration begins. It does not start with systems or processes. It starts with leaders choosing to listen, to explain, and to show up with honesty.
-
-## Reflection
-
-If I could summarize what I’ve learned in one sentence, it would be this: **psychological safety is not built by policies, it’s built by people who show up with honesty and curiosity.**
-
-When leaders model openness, transparency, and empathy, teams don’t just perform better, **they thrive**. They collaborate, innovate, and grow together.
-
-Building safety takes time, consistency, and courage. But once you have it, it becomes the quiet strength behind everything a team can achieve.
-
-1.  Timothy R. Clark. “_The 4 Stages of Psychological Safety: Defining the Path to Inclusion and Innovation_.” Berrett-Koehler Publishers. March 3, 2020 [↩︎](#5a4e8570-6991-4e1f-b422-95e4b53ae11f-link)
+My team never needed me to promise that speaking up was safe. They needed me to listen, explain my decisions, and keep their dignity intact when the conversation became hard.

--- a/src/content/essays/write-in-markdown/write-in-markdown.mdx
+++ b/src/content/essays/write-in-markdown/write-in-markdown.mdx
@@ -1,12 +1,14 @@
 ---
 title: Why I Write in Markdown for Most of My Work
 date: 2015-09-01
-updated: 2026-05-12
+updated: 2026-08-28
 sticky: false
 cornerstone: true
-excerpt: Markdown keeps writing fast, portable, and distraction-free, working across tools so you focus on ideas, not formatting or interfaces instead.
+excerpt: Markdown keeps my hands on the keyboard and my drafts in files I can open anywhere. Five bits of syntax cover almost everything I write.
 newsletterIntro: |-
-  Markdown keeps writing fast, portable, and distraction-free, working across tools so you focus on ideas, not formatting or interfaces instead.
+  I have changed editors, publishing systems, and computers since I began writing in Markdown. The files kept working.
+
+  This essay explains why plain text still suits most of my work and how to try it without rebuilding your workflow.
 categories:
   - Observations
 tags:
@@ -25,174 +27,117 @@ import ulysses from "./ulysses.jpg";
 
 <QuickSummary>
 
-- I write in Markdown because it is just plain text with light structure, which keeps writing readable and portable.
-- Using the same syntax across tools protects focus and makes it easier to move work around.
-- WordPress and many modern apps understand Markdown patterns, so the habit scales well.
-- Rich editors offer more features, but Markdown is the one that reliably gets out of the way.
+- Markdown lets me add headings, links, and lists without leaving the keyboard.
+- Plain text keeps my drafts readable when I move them between tools.
+- Five bits of syntax cover most of my writing.
+- Markdown cannot improve a weak idea, but it gives me fewer interface choices to manage while I work on one.
 
 </QuickSummary>
 
 Writing feels better when the tool disappears.
 
-Most writing apps promise help. They offer menus, templates, formatting bars, and collaboration modes. They look powerful. In practice, they often slow down the only thing that matters, which is getting words out of your head and onto the page.
+Most writing apps put menus, templates, formatting bars, and collaboration controls around the page. I start thinking about the interface when I should be holding onto a sentence.
 
-Markdown never tried to be helpful in that way. It does almost nothing, and that is why I write in Markdown for most of my work.
+Markdown gives me plain text and a few characters for structure. I began using it for documentation and internal posts that had to survive years of edits and moves between tools. I kept using it because it asks so little of me while I write.
 
-I started with it for boring reasons. I needed a clean way to write documentation and internal posts that would survive copy-paste, different tools, and years of edits. Markdown solved that. Over time it did something else. It changed how I think about writing work itself.
+## Markdown in Five Patterns
 
-## What Markdown Actually Is
+I use Markdown to add structure while keeping the source easy to read.
 
-Markdown is just plain text with small hints.
+I use five patterns for most of my work:
 
-You type normal sentences. When you want a heading, you start the line with `#`. When you want emphasis, you wrap a word in `*asterisks*`. Lists are just lines that start with `-` or `*`.
+- `#` for a main heading
+- `##` for a subheading
+- `-` for a list item
+- `*emphasis*` for italics
+- `[link text](https://example.com)` for a link
 
-You are not dragging sliders or choosing fonts. You are describing intent—[what makes Markdown work](/what-is-vibe-coding-how-to-do-it/).
+I can understand the file before anything renders it. A heading still looks like a heading, and a list still looks like a list. A renderer can turn the same file into HTML, a documentation page, or another format later.
 
-- This line is a heading.
-- This word should stand out.
-- This group of lines is a list.
+Keeping the text separate from its final layout lets me write before I decide how the finished page should look.
 
-The text stays readable in its raw form. If you never convert it, you can still understand it. When you do render it, it becomes clean HTML, or a nicely formatted page, or a help article in your docs.
+## Keeping My Hands on the Keyboard
 
-That gap between plain text and finished output is the point. Markdown does not ask you to commit to a final shape. It only asks you to be clear about structure.
+I find difficult writing easier when I can stay with the sentence. Because [I blog with ADHD](/adhd-planner/), I notice each interruption.
 
-## Writing Without Friction
+A trip to a formatting menu takes only a few seconds, but it interrupts whatever I was trying to hold in my head. I have to find the heading control, choose a list type, or switch apps because one editor handles code blocks better than another.
 
-Good writing feels like a straight line between thought and hand.
+With Markdown, I type `##` and continue. I start a list with `-`. I write the link where I need it rather than leaving the sentence to open a dialog.
 
-Every time you leave the keyboard, that line bends. You move the mouse to find the bold button. You hunt inside a menu for “Heading 2”. You switch to a different app because the current one does not handle code blocks well.
-
-Each small interruption is harmless on its own. Together they add a background drag. You feel it most on hard pieces. The part of your brain that should be holding onto an idea is busy managing the interface.
-
-Markdown reduces that drag—a [plain tool that holds the boring stuff in place](/tools-for-adhd-leadership/).
-
-Everything happens from the keyboard.
-
-- Need a heading? Type `##` and keep going.
-- Need a list? Start a line with `-` and write the first item.
-- Need a link? Write `(url)` and move on.
-
-No modal windows. No “format painter”. No mode switches. The tool is not trying to be clever. It is just following along.
-
-For me, this matters in the kind of writing I do most days. Documentation. Internal posts. Support replies. Essay drafts. The content is different, but the structure is the same, and Markdown stays stable under all of it.
+For me, this matters across documentation, internal posts, support replies, and essay drafts. The subject changes, but my hands use the same patterns.
 
 <Figure src={markdownFocus} alt={"Focused man working at a desktop computer in a colorful home office with plants, stationery, and a desk lamp."}>
   Photo by [Vitaly Gariev](https://unsplash.com/@silverkblack?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)
 </Figure>
 
-## One Syntax, Many Places
+## One Habit Across Different Tools
 
-The real strength of Markdown is not any single editor. It is the fact that the same tiny language shows up almost everywhere.
-
-In daily work I see it in:
+I have used Markdown patterns in:
 
 - WordPress posts and pages
 - P2 threads
 - GitHub READMEs
-- Documentation portals ([screenshots included](/shotlist-automatic-annotated-screenshots/))
+- Documentation portals, including work made with [shotlist](/shotlist-automatic-annotated-screenshots/)
 - Slack messages
-- AI prompt templates
-- Google Docs ([as of 2022](https://techcrunch.com/2022/03/30/google-adds-limited-markdown-support-to-google-docs/))
+- AI prompt files
+- Google Docs, which added [limited Markdown support in 2022](https://techcrunch.com/2022/03/30/google-adds-limited-markdown-support-to-google-docs/)
 
-I can move between these tools without changing how I write. A heading is a heading. A list is a list. The same characters mean the same thing in each place.
+The support differs. Some tools store Markdown. Others recognise a pattern and turn it into their own heading or list. Either way, I do not have to learn a new writing habit when I change tools.
 
-That consistency does two useful things.
+Using the same patterns across tools protects my attention and keeps the text portable. I can draft a support reply in a file, paste it into another tool, and keep the structure. If the destination does not understand Markdown, the source remains readable enough to fix by hand.
 
-First, it protects my attention. I do not have to relearn a new toolbar every time I switch context. My hands do the same thing, and my brain can stay on the problem.
+## Markdown in WordPress
 
-Second, it makes my writing portable. A support reply drafted in a plain text file on my laptop can be pasted into WordPress, Slack, or a doc without breaking. The structure survives the trip.
+WordPress did not support Markdown on its own when I started. I used Jetpack’s Markdown module to convert the syntax into HTML when I saved a post.
 
-## Markdown Inside WordPress
+WordPress later added block-editor shortcuts for some of the patterns. Starting a line with `#` creates a heading block. Typing `-` followed by a space starts a list. WordPress converts the structure while I keep writing the way I do in a text file.
 
-When I first started, WordPress did not understand Markdown on its own. I used Jetpack’s Markdown module, which converted the syntax into HTML on save. It worked, but it added an extra layer to think about.
+Many tools now support their own subset of Markdown. The details vary, but the habit carries across them.
 
-Then the block editor arrived and changed the picture.
+## The Editors Have Changed
 
-WordPress learned just enough Markdown to be helpful. If you start a line with `#`, it becomes a heading block. If you type `-` and space, you are now in a list. The editor watches for the patterns and quietly turns your habit of writing in Markdown inside WordPress into structured content.
+I have tried many Markdown editors. Browsing writing tools can become a convenient way to avoid writing.
 
-This feels like the right balance. WordPress adapts to how I already write instead of asking me to click my way into whatever block I want. The habit I use in plain text files carries directly into the editor.
+[Ulysses](https://ulysses.app/) is the long-form editor I kept. It stores each piece as a sheet, handles a large library, and exports clean files. For a while, most of my writing began there.
 
-That same pattern exists outside WordPress too. Many modern tools speak a kind of Markdown dialect now. You can feel the influence of the original idea even when the exact syntax changes.
+My work now lives in more places. I write internal discussions in P2, public essays in MDX files, and notes in plain text. I use Markdown in all three. The app matters less because the underlying files remain simple.
 
-## The Markdown Tools I Actually Use
-
-I have tried many editors over the years. It is easy to get lost in this part, because writing tools are often more fun to explore than writing itself.
-
-[Ulysses](https://ulysses.app/) on macOS is the one long-form editor that stuck. It treats each piece as a sheet, handles large libraries well, and exports clean files. For a while, almost everything I wrote started there.
-
-Today, my writing is more spread out:
-
-- WordPress for public posts.
-- P2 for internal discussions.
-- Plain text files in a synced folder for notes and drafts.
-
-Markdown is the thread that connects all of them. It is the same pattern in each place. Headings, lists, emphasis, and links. The exact app becomes less important, which is a comfortable place to be.
-
-If Ulysses vanished, or WordPress changed, or I needed to switch laptops, my writing would still live in simple text files that any editor can open.
+If Ulysses disappeared or I changed publishing systems again, another editor could open the work.
 
 <Figure src={ulysses} alt={"Worn blue-covered copy of Ulysses by James Joyce resting on a white surface, with frayed pages and edges."}>
   By Geoffrey Barker – Own work, CC BY-SA 4.0
 </Figure>
 
-## Why I Still Write in Markdown
+## Why Plain Text Still Wins for Me
 
-By now, there are many other options.
+Modern editors offer AI assistants, goals, databases, and visual layout tools. Some of those features help with specific jobs. They also give me more decisions to make before I finish a draft.
 
-Some editors give you AI assistants, goal trackers, and complex outlining tools. Some let you design the final layout as you write. Others try to be full publishing platforms on their own.
+Markdown stays useful because it does less:
 
-I test these sometimes. They are impressive. They also tend to pull my attention outward. I end up thinking about features, templates, and workflows instead of the thing I sat down to write.
+- I can postpone decisions about the final layout.
+- I add structure only when I need it.
+- I can move the text without exporting from a proprietary format.
 
-Markdown remains the only system that consistently stays out of the way.
+A `.md` file I wrote ten years ago still opens in any text editor. I do not need the company that made my old app to keep a server running or maintain an export tool.
 
-- It does not assume anything about the final form.
-- It adds structure when I ask and stays quiet otherwise.
-- It works the same across almost every tool I use.
+I still cannot move every plain-text file without some cleanup. Markdown has dialects, links can break, and an MDX file can depend on components. The words remain accessible even when the publishing system around them changes.
 
-There is also a simple, practical reason: longevity.
+## Try It on One Piece of Work
 
-Ten years from now, any text editor will still open a `.md` or `.txt` file. Plain text writing means no vendor lock-in, no proprietary format to migrate away from, and no sudden “version 2” that breaks older drafts.
+You do not need to replace your notes app or move your archive to test Markdown.
 
-My words are just text. If I want to move them into a new system, I can. If I want to keep them as they are, that works too.
+1. **Pick one place where you write.** Keep the tool you use now.
+2. **Learn the five patterns above.** Ignore the rest for a week.
+3. **Use a real task.** Write a support reply, an internal post, or a draft instead of practising on sample text.
+4. **Notice each trip to the mouse.** Check whether a Markdown pattern could keep you in the sentence.
+5. **Decide after a week.** The first hour mostly measures how unfamiliar the syntax feels.
 
-## How To Start Using Markdown This Week
+A short test tells you whether the tradeoff suits your work without asking you to build another productivity system.
 
-If you want to try Markdown, you do not need a whole new system. You can treat this week as a small test.
+## What Markdown Cannot Do
 
-Here is a simple way to do that.
+Markdown will not fix a weak argument or fill an empty page. It also becomes awkward when I need precise layouts, complex tables, or heavy collaboration in a visual document.
 
-1.  **Pick one place where you already write**. Maybe it is WordPress, P2, a docs tool, or a folder of notes. Do not change the tool. Just decide that for the next seven days, anything you write there will use Markdown.
-2.  **Learn five patterns and ignore the rest.** You can do a lot of real work with only these:
-    - `#` for a main heading
-    - `##` for a subheading
-    - `-` for a list item
-    - `*emphasis*` for italics
-    - `[link text](https://example.com)` for links
-3.  **Draft in plain text**. Open a basic editor on your computer and write there first. No formatting bar. No distractions. When you are done, paste it into your tool and let it handle the rendering.
-4.  **Use one real piece of work as a test**. Do not practice on a fake example. Write a real support reply, a real internal post, or a real blog draft in Markdown. Notice when your hands reach for the mouse and ask if there is a Markdown shortcut instead.
-5.  **Decide after one week, not one hour.** The first day feels strange because your habits are different. By the third or fourth day, it usually feels normal. At the end of the week, you can decide if the tradeoffs are worth it for you.
+For the work it suits, it removes choices I do not want to make while drafting. I can think about the reader, the order of the ideas, and the sentence in front of me.
 
-The goal is not to become a Markdown expert. The goal is to see how it feels when the tool asks less of you while you write.
-
-## Clarity By Subtraction
-
-Most of the time, productivity advice is about adding more.
-
-More tools. More views. More ways to optimize. Markdown takes the opposite path. It removes options until only a few useful patterns remain.
-
-That constraint is where the clarity comes from.
-
-When headings are just `#`, you stop worrying about typography. When emphasis is simply `*this*`, you stop tinkering with styles. When lists are only lines that start with `-`, you stop thinking about spacing.
-
-You are left with questions that matter more.
-
-- What am I trying to say.
-- Who is this for.
-- Is this the clearest version of the idea I can write today.
-
-Markdown is not magic. It will not fix a bad argument or fill an empty page. What it does is reduce the number of things you have to manage while you are doing the harder part.
-
-That is why I still write in it.
-
-It keeps my hands on the keyboard. It keeps my drafts portable. It aligns the tools I use with the kind of work I care about, which is slow, honest writing about where humans and technology keep bumping into each other. When the tool itself writes, though, honesty becomes a different question—less about which tools to choose, more about [what authorship means in a collaboration with language](/vibe-writing-line-between-human-machine/).
-
-In the end, that is enough.
+That is why I still write in Markdown. It keeps my hands on the keyboard and leaves my words in a form I can carry to the next tool.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import Button from "../components/Button.astro";
 import Highlight from "../components/Highlight.astro";
 import Home from "../layouts/Home.astro";
 import Label from "../components/Label.astro";
@@ -11,7 +10,11 @@ import { getAllPosts } from "../lib/essays";
 const posts = await getAllPosts();
 const [lead, ...rest] = posts;
 const recent = rest.slice(0, 6);
-const cornerstones = posts.filter((post) => post.cornerstone);
+
+const currentMonth = new Date().toLocaleString("default", {
+  month: "long",
+  year: "numeric",
+});
 ---
 
 <Home
@@ -24,94 +27,46 @@ const cornerstones = posts.filter((post) => post.cornerstone);
     class="flex flex-col items-start gap-6 pt-8 md:flex-row md:items-end md:justify-between md:gap-10"
   >
     <div class="space-y-4">
-      <p class="label max-w-lg text-left">Latest writing</p>
-      <h1 class="max-w-lg">Latest essays</h1>
+      <p class="label max-w-lg text-left">{currentMonth}</p>
+      <h1 class="max-w-lg">New This Month</h1>
     </div>
-    <p class="lead max-w-md text-left text-lg md:text-right">
-      Honest writing on leadership, code, and the overlap between humans and
-      tech.
+    <p class="lead max-w-sm text-left text-lg md:text-right">
+      New essays each month on leadership, programming, and the messy overlap
+      between humans and tech.
     </p>
   </div>
 
   {lead && <Highlight slot="highlight" post={lead} />}
 
-  <section class="pb-16">
-    <h2 class="sr-only">More recent essays</h2>
-    <div class="grid gap-x-12 md:grid-cols-2">
-      {
-        recent.map((post) => {
-          const postDate = new Date(post.date).toLocaleString("default", {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-          });
+  <section class="grid gap-x-12 pb-16 md:grid-cols-2">
+    <h2 class="sr-only">More essays</h2>
+    {
+      recent.map((post) => {
+        const postDate = new Date(post.date).toLocaleString("default", {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+        });
 
-          return (
-            <article class="border-line space-y-3 border-b py-6 last:border-0 md:nth-last-[-n+2]:border-0">
-              <div class="flex justify-between">
-                <p class="label text-left">
-                  <TaxLinks names={post.categories} base="section" />
-                </p>
-                <div class="meta flex gap-2">
-                  <p>{postDate}</p> &middot;
-                  <ReadTime content={post.body} />
-                </div>
+        return (
+          <article class="border-line space-y-3 border-b py-6 nth-last-[-n+2]:border-0">
+            <div class="flex justify-between">
+              <p class="label text-left">
+                <TaxLinks names={post.categories} base="section" />
+              </p>
+              <div class="meta flex gap-2">
+                <p>{postDate}</p> &middot;
+                <ReadTime content={post.body} />
               </div>
-              <h3>
-                <a href={post.url} data-track="Homepage latest essay click">
-                  {post.title}
-                </a>
-              </h3>
-              <p class="excerpt text-base">{post.excerpt}</p>
-              <a
-                href={post.url}
-                data-track="Homepage latest essay click"
-                class="label inline-block pt-1"
-                aria-label={`Read ${post.title}`}
-              >
-                Read essay →
-              </a>
-            </article>
-          );
-        })
-      }
-    </div>
-    <div class="mt-8 flex justify-center">
-      <Button href="/essays/" icon="arrow">Browse all essays</Button>
-    </div>
-  </section>
-
-  <section class="border-line border-t py-16" aria-labelledby="cornerstones">
-    <div class="max-w-2xl">
-      <Label>Start here</Label>
-      <h2 id="cornerstones" class="mt-3">Cornerstone essays</h2>
-      <p class="text-muted mt-3 text-base">
-        The enduring ideas and practical guides at the centre of this site.
-      </p>
-    </div>
-    <div class="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {
-        cornerstones.map((post) => (
-          <article class="border-line bg-surface flex flex-col border p-6">
-            <p class="label text-left">{post.categories.join(", ")}</p>
-            <h3 class="mt-3 text-xl">
-              <a href={post.url} data-track="Homepage cornerstone essay click">
-                {post.title}
-              </a>
+            </div>
+            <h3>
+              <a href={post.url}>{post.title}</a>
             </h3>
-            <p class="excerpt text-muted mt-3 flex-1">{post.excerpt}</p>
-            <a
-              href={post.url}
-              data-track="Homepage cornerstone essay click"
-              class="label mt-5 inline-block"
-              aria-label={`Read ${post.title}`}
-            >
-              Read essay →
-            </a>
+            <p class="excerpt text-base">{post.excerpt}</p>
           </article>
-        ))
-      }
-    </div>
+        );
+      })
+    }
   </section>
 
   <section class="border-line border-t py-16">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import Button from "../components/Button.astro";
 import Highlight from "../components/Highlight.astro";
 import Home from "../layouts/Home.astro";
 import Label from "../components/Label.astro";
@@ -10,11 +11,6 @@ import { getAllPosts } from "../lib/essays";
 const posts = await getAllPosts();
 const [lead, ...rest] = posts;
 const recent = rest.slice(0, 6);
-
-const currentMonth = new Date().toLocaleString("default", {
-  month: "long",
-  year: "numeric",
-});
 ---
 
 <Home
@@ -27,46 +23,55 @@ const currentMonth = new Date().toLocaleString("default", {
     class="flex flex-col items-start gap-6 pt-8 md:flex-row md:items-end md:justify-between md:gap-10"
   >
     <div class="space-y-4">
-      <p class="label max-w-lg text-left">{currentMonth}</p>
-      <h1 class="max-w-lg">New This Month</h1>
+      <p class="label max-w-lg text-left">Latest writing</p>
+      <h1 class="max-w-lg">Latest essays</h1>
     </div>
-    <p class="lead max-w-sm text-left text-lg md:text-right">
-      New essays each month on leadership, programming, and the messy overlap
-      between humans and tech.
+    <p class="lead max-w-md text-left text-lg md:text-right">
+      Honest writing on leadership, code, and the overlap between humans and
+      tech.
     </p>
   </div>
 
   {lead && <Highlight slot="highlight" post={lead} />}
 
-  <section class="grid gap-x-12 pb-16 md:grid-cols-2">
-    <h2 class="sr-only">More essays</h2>
-    {
-      recent.map((post) => {
-        const postDate = new Date(post.date).toLocaleString("default", {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
-        });
+  <section class="pb-16" aria-labelledby="recent-essays">
+    <h2 id="recent-essays" class="pt-4 text-2xl">More recent essays</h2>
+    <div class="grid gap-x-12 md:grid-cols-2">
+      {
+        recent.map((post) => {
+          const postDate = new Date(post.date).toLocaleString("default", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+          });
 
-        return (
-          <article class="border-line space-y-3 border-b py-6 nth-last-[-n+2]:border-0">
-            <div class="flex justify-between">
-              <p class="label text-left">
-                <TaxLinks names={post.categories} base="section" />
-              </p>
-              <div class="meta flex gap-2">
-                <p>{postDate}</p> &middot;
-                <ReadTime content={post.body} />
+          return (
+            <article class="border-line space-y-3 border-b py-6 last:border-0 md:nth-last-[-n+2]:border-0">
+              <div class="flex justify-between">
+                <p class="label text-left">
+                  <TaxLinks names={post.categories} base="section" />
+                </p>
+                <div class="meta flex gap-2">
+                  <p>{postDate}</p> &middot;
+                  <ReadTime content={post.body} />
+                </div>
               </div>
-            </div>
-            <h3>
-              <a href={post.url}>{post.title}</a>
-            </h3>
-            <p class="excerpt text-base">{post.excerpt}</p>
-          </article>
-        );
-      })
-    }
+              <h3>
+                <a href={post.url} data-track="Homepage recent essay click">
+                  {post.title}
+                </a>
+              </h3>
+              <p class="excerpt text-base">{post.excerpt}</p>
+            </article>
+          );
+        })
+      }
+    </div>
+    <div class="mt-8 flex justify-center">
+      <Button href="/essays/" data-track="Homepage essay archive click">
+        Browse all essays →
+      </Button>
+    </div>
   </section>
 
   <section class="border-line border-t py-16">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import Button from "../components/Button.astro";
 import Highlight from "../components/Highlight.astro";
 import Home from "../layouts/Home.astro";
 import Label from "../components/Label.astro";
@@ -10,11 +11,7 @@ import { getAllPosts } from "../lib/essays";
 const posts = await getAllPosts();
 const [lead, ...rest] = posts;
 const recent = rest.slice(0, 6);
-
-const currentMonth = new Date().toLocaleString("default", {
-  month: "long",
-  year: "numeric",
-});
+const cornerstones = posts.filter((post) => post.cornerstone);
 ---
 
 <Home
@@ -27,46 +24,94 @@ const currentMonth = new Date().toLocaleString("default", {
     class="flex flex-col items-start gap-6 pt-8 md:flex-row md:items-end md:justify-between md:gap-10"
   >
     <div class="space-y-4">
-      <p class="label max-w-lg text-left">{currentMonth}</p>
-      <h1 class="max-w-lg">New This Month</h1>
+      <p class="label max-w-lg text-left">Latest writing</p>
+      <h1 class="max-w-lg">Latest essays</h1>
     </div>
-    <p class="lead max-w-sm text-left text-lg md:text-right">
-      New essays each month on leadership, programming, and the messy overlap
-      between humans and tech.
+    <p class="lead max-w-md text-left text-lg md:text-right">
+      Honest writing on leadership, code, and the overlap between humans and
+      tech.
     </p>
   </div>
 
   {lead && <Highlight slot="highlight" post={lead} />}
 
-  <section class="grid gap-x-12 pb-16 md:grid-cols-2">
-    <h2 class="sr-only">More essays</h2>
-    {
-      recent.map((post) => {
-        const postDate = new Date(post.date).toLocaleString("default", {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
-        });
+  <section class="pb-16">
+    <h2 class="sr-only">More recent essays</h2>
+    <div class="grid gap-x-12 md:grid-cols-2">
+      {
+        recent.map((post) => {
+          const postDate = new Date(post.date).toLocaleString("default", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+          });
 
-        return (
-          <article class="border-line space-y-3 border-b py-6 nth-last-[-n+2]:border-0">
-            <div class="flex justify-between">
-              <p class="label text-left">
-                <TaxLinks names={post.categories} base="section" />
-              </p>
-              <div class="meta flex gap-2">
-                <p>{postDate}</p> &middot;
-                <ReadTime content={post.body} />
+          return (
+            <article class="border-line space-y-3 border-b py-6 last:border-0 md:nth-last-[-n+2]:border-0">
+              <div class="flex justify-between">
+                <p class="label text-left">
+                  <TaxLinks names={post.categories} base="section" />
+                </p>
+                <div class="meta flex gap-2">
+                  <p>{postDate}</p> &middot;
+                  <ReadTime content={post.body} />
+                </div>
               </div>
-            </div>
-            <h3>
-              <a href={post.url}>{post.title}</a>
+              <h3>
+                <a href={post.url} data-track="Homepage latest essay click">
+                  {post.title}
+                </a>
+              </h3>
+              <p class="excerpt text-base">{post.excerpt}</p>
+              <a
+                href={post.url}
+                data-track="Homepage latest essay click"
+                class="label inline-block pt-1"
+                aria-label={`Read ${post.title}`}
+              >
+                Read essay →
+              </a>
+            </article>
+          );
+        })
+      }
+    </div>
+    <div class="mt-8 flex justify-center">
+      <Button href="/essays/" icon="arrow">Browse all essays</Button>
+    </div>
+  </section>
+
+  <section class="border-line border-t py-16" aria-labelledby="cornerstones">
+    <div class="max-w-2xl">
+      <Label>Start here</Label>
+      <h2 id="cornerstones" class="mt-3">Cornerstone essays</h2>
+      <p class="text-muted mt-3 text-base">
+        The enduring ideas and practical guides at the centre of this site.
+      </p>
+    </div>
+    <div class="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {
+        cornerstones.map((post) => (
+          <article class="border-line bg-surface flex flex-col border p-6">
+            <p class="label text-left">{post.categories.join(", ")}</p>
+            <h3 class="mt-3 text-xl">
+              <a href={post.url} data-track="Homepage cornerstone essay click">
+                {post.title}
+              </a>
             </h3>
-            <p class="excerpt text-base">{post.excerpt}</p>
+            <p class="excerpt text-muted mt-3 flex-1">{post.excerpt}</p>
+            <a
+              href={post.url}
+              data-track="Homepage cornerstone essay click"
+              class="label mt-5 inline-block"
+              aria-label={`Read ${post.title}`}
+            >
+              Read essay →
+            </a>
           </article>
-        );
-      })
-    }
+        ))
+      }
+    </div>
   </section>
 
   <section class="border-line border-t py-16">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,9 +8,27 @@ import ReadTime from "../components/ReadTime.astro";
 import TaxLinks from "../components/TaxLinks.astro";
 import { getAllPosts } from "../lib/essays";
 
+const bestReadSlugs = [
+  "gaming-made-me-better-leader",
+  "psychological-safety-in-teams-people-first-leadership",
+  "how-to-choose-a-software-license-for-your-next-project",
+  "write-in-markdown",
+  "do-you-trust-your-instincts-making-smart-wordpress-choices",
+  "woocommerce-attributes-vs-variations",
+];
+
 const posts = await getAllPosts();
 const [lead, ...rest] = posts;
 const recent = rest.slice(0, 6);
+const postsBySlug = new Map(posts.map((post) => [post.slug, post]));
+const bestReads = bestReadSlugs.map((slug) => {
+  const post = postsBySlug.get(slug);
+  if (!post) throw new Error(`Best Reads essay not found: ${slug}`);
+  if (!post.cornerstone) {
+    throw new Error(`Best Reads essay is not a cornerstone: ${slug}`);
+  }
+  return post;
+});
 ---
 
 <Home
@@ -71,6 +89,40 @@ const recent = rest.slice(0, 6);
       <Button href="/essays/" data-track="Homepage essay archive click">
         Browse all essays →
       </Button>
+    </div>
+  </section>
+
+  <section class="border-line border-t py-16" aria-labelledby="best-reads">
+    <header class="max-w-2xl">
+      <h2 id="best-reads">Best reads</h2>
+      <p class="text-muted mt-3 text-base">
+        Enduring essays and practical guides worth starting with.
+      </p>
+    </header>
+    <div class="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {
+        bestReads.map((post) => (
+          <article class="border-line bg-surface flex flex-col border p-6">
+            <p class="label text-left">
+              <TaxLinks names={post.categories} base="section" />
+            </p>
+            <h3 class="mt-3 text-xl">
+              <a href={post.url} data-track="Homepage best read click">
+                {post.title}
+              </a>
+            </h3>
+            <p class="excerpt text-muted mt-3 flex-1">{post.excerpt}</p>
+            <a
+              href={post.url}
+              data-track="Homepage best read click"
+              class="label mt-5 inline-block"
+              aria-label={`Read ${post.title}`}
+            >
+              Read essay →
+            </a>
+          </article>
+        ))
+      }
     </div>
   </section>
 

--- a/test/agent-readable-build.test.mjs
+++ b/test/agent-readable-build.test.mjs
@@ -112,6 +112,66 @@ test("the production build exposes homepage and agent-readable navigation", () =
     "Homepage essay archive click",
   );
 
+  const bestReadSlugs = [
+    "gaming-made-me-better-leader",
+    "psychological-safety-in-teams-people-first-leadership",
+    "how-to-choose-a-software-license-for-your-next-project",
+    "write-in-markdown",
+    "do-you-trust-your-instincts-making-smart-wordpress-choices",
+    "woocommerce-attributes-vs-variations",
+  ];
+  const bestReads = homepage.querySelector('[aria-labelledby="best-reads"]');
+  assert.ok(bestReads);
+  assert.equal(bestReads.previousElementSibling, recent);
+  assert.equal(
+    bestReads.nextElementSibling.querySelector("h2").textContent.trim(),
+    "Downloads & Tools",
+  );
+  assert.equal(bestReads.querySelector("h2").textContent.trim(), "Best reads");
+  assert.equal(
+    bestReads.querySelector("header p").textContent.trim(),
+    "Enduring essays and practical guides worth starting with.",
+  );
+  assert.doesNotMatch(bestReads.textContent, /cornerstone/i);
+
+  const bestReadCards = Array.from(bestReads.querySelectorAll("article"));
+  assert.equal(bestReadCards.length, bestReadSlugs.length);
+  assert.deepEqual(
+    inventory.published
+      .filter(({ cornerstone }) => cornerstone)
+      .map(({ slug }) => slug)
+      .sort(),
+    [...bestReadSlugs].sort(),
+  );
+
+  for (const [index, article] of bestReadCards.entries()) {
+    const essay = inventory.get(bestReadSlugs[index]);
+    const titleLink = article.querySelector("h3 a");
+    const sectionLink = article.querySelector(".label a");
+    const excerpt = article.querySelector(".excerpt");
+    const cta = Array.from(article.querySelectorAll("a")).find(
+      (link) => link.textContent.trim() === "Read essay →",
+    );
+
+    assert.equal(article.closest("a"), null);
+    assert.equal(titleLink.textContent.trim(), essay.title);
+    assert.equal(titleLink.getAttribute("href"), essay.pathname);
+    assert.equal(
+      titleLink.getAttribute("data-track"),
+      "Homepage best read click",
+    );
+    assert.equal(
+      sectionLink.getAttribute("href"),
+      `/section/${essay.categories[0].slug}/`,
+    );
+    assert.equal(sectionLink.hasAttribute("data-track"), false);
+    assert.equal(excerpt.textContent.trim(), essay.excerpt);
+    assert.equal(excerpt.closest("a"), null);
+    assert.equal(cta.getAttribute("href"), essay.pathname);
+    assert.equal(cta.getAttribute("aria-label"), `Read ${essay.title}`);
+    assert.equal(cta.getAttribute("data-track"), "Homepage best read click");
+  }
+
   const expectedUrls = new Set([
     ...inventory.published.map(({ pathname }) => markdownUrl(pathname)),
     ...authoredPages.map(markdownUrl),

--- a/test/agent-readable-build.test.mjs
+++ b/test/agent-readable-build.test.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
+import { createWindow } from "@mixmark-io/domino";
 import { loadEssayInventory } from "../src/lib/essay-inventory.mjs";
 
 const repositoryRoot = path.resolve(import.meta.dirname, "..");
@@ -27,7 +28,7 @@ const withoutFencedCode = (markdown) =>
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-test("the production agent index leads to every editorial Markdown alternative", () => {
+test("the production build exposes homepage and agent-readable navigation", () => {
   const build = spawnSync("npm", ["run", "build"], {
     cwd: repositoryRoot,
     encoding: "utf8",
@@ -36,6 +37,81 @@ test("the production agent index leads to every editorial Markdown alternative",
   assert.equal(build.status, 0, build.stdout + build.stderr);
 
   const inventory = loadEssayInventory();
+  const publishedEssays = [...inventory.published].sort(
+    (a, b) =>
+      b.publishedAt.valueOf() - a.publishedAt.valueOf() ||
+      a.slug.localeCompare(b.slug),
+  );
+  const [leadEssay, ...remainingEssays] = publishedEssays;
+  const homepage = createWindow(
+    readFileSync(path.join(repositoryRoot, "dist", "index.html"), "utf8"),
+  ).document;
+  const lead = homepage.querySelector("#highlight");
+  assert.ok(lead);
+  const leadCoverLink = lead.querySelector("picture").closest("a");
+  const leadTitleLink = lead.querySelector("h2 a");
+  const leadExcerpt = lead.querySelector(".lead");
+  const leadSectionLink = lead.querySelector(".label a");
+  const recent = homepage.querySelector('[aria-labelledby="recent-essays"]');
+  assert.ok(recent);
+  const recentEssays = Array.from(recent.querySelectorAll("article"));
+  const archiveLink = recent.querySelector('a[href="/essays/"]');
+
+  assert.equal(
+    homepage.querySelector("h1").textContent.trim(),
+    "Latest essays",
+  );
+  assert.equal(leadCoverLink.getAttribute("href"), leadEssay.pathname);
+  assert.equal(
+    leadCoverLink.getAttribute("data-track"),
+    "Homepage lead essay click",
+  );
+  assert.equal(
+    leadCoverLink.getAttribute("aria-label"),
+    `Read ${leadEssay.title}`,
+  );
+  assert.equal(leadTitleLink.getAttribute("href"), leadEssay.pathname);
+  assert.equal(
+    leadTitleLink.getAttribute("data-track"),
+    "Homepage lead essay click",
+  );
+  assert.equal(leadExcerpt.closest("a"), null);
+  assert.equal(
+    leadSectionLink.getAttribute("href"),
+    `/section/${leadEssay.categories[0].slug}/`,
+  );
+  assert.equal(leadSectionLink.hasAttribute("data-track"), false);
+  assert.equal(
+    recent.querySelector("h2").textContent.trim(),
+    "More recent essays",
+  );
+  assert.equal(recentEssays.length, 6);
+
+  for (const [index, article] of recentEssays.entries()) {
+    const essay = remainingEssays[index];
+    const titleLink = article.querySelector("h3 a");
+    const sectionLink = article.querySelector(".label a");
+    const excerpt = article.querySelector(".excerpt");
+    assert.equal(titleLink.textContent.trim(), essay.title);
+    assert.equal(titleLink.getAttribute("href"), essay.pathname);
+    assert.equal(
+      titleLink.getAttribute("data-track"),
+      "Homepage recent essay click",
+    );
+    assert.equal(
+      sectionLink.getAttribute("href"),
+      `/section/${essay.categories[0].slug}/`,
+    );
+    assert.equal(sectionLink.hasAttribute("data-track"), false);
+    assert.equal(excerpt.closest("a"), null);
+  }
+
+  assert.equal(archiveLink.textContent.trim(), "Browse all essays →");
+  assert.equal(
+    archiveLink.getAttribute("data-track"),
+    "Homepage essay archive click",
+  );
+
   const expectedUrls = new Set([
     ...inventory.published.map(({ pathname }) => markdownUrl(pathname)),
     ...authoredPages.map(markdownUrl),


### PR DESCRIPTION
## Summary

- clarify the publication's primary audience and refine the six evergreen hub essays
- centralize agent configuration in AGENTS.md
- improve latest-essay discovery and taxonomy navigation on the homepage
- add the ordered Best Reads section with stable cornerstone links
- add Fathom click events and production-HTML regression coverage

## Verification

- `npm test`
- `npm run build`
- `npm run format:check`
- `npm run check:links`
- responsive browser review at mobile, tablet, and desktop widths
- independent code review

Implements #21.
