### PR TITLE
Cache Astro image derivatives in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
 
       - run: npm ci
 
+      - name: Restore Astro image cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules/.astro
+          key: ${{ runner.os }}-astro-images-${{ hashFiles('package-lock.json', 'astro.config.mjs', 'src/**/*.astro', 'src/**/*.avif', 'src/**/*.gif', 'src/**/*.jpeg', 'src/**/*.jpg', 'src/**/*.png', 'src/**/*.webp') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-images-
+
       - name: Test failure detection
         run: npm test
 

--- a/test/ci-stages.test.mjs
+++ b/test/ci-stages.test.mjs
@@ -1,5 +1,11 @@
 import assert from "node:assert/strict";
-import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -12,6 +18,24 @@ const run = (command, args) =>
     cwd: repositoryRoot,
     encoding: "utf8",
   });
+
+test("CI restores Astro's image cache after npm ci and before tests", () => {
+  const workflow = readFileSync(
+    path.join(repositoryRoot, ".github", "workflows", "ci.yml"),
+    "utf8",
+  );
+  const installIndex = workflow.indexOf("- run: npm ci");
+  const imageCacheIndex = workflow.indexOf("path: node_modules/.astro");
+  const testIndex = workflow.indexOf("run: npm test");
+
+  assert.notEqual(installIndex, -1, "CI must install dependencies");
+  assert.notEqual(imageCacheIndex, -1, "CI must cache Astro image derivatives");
+  assert.notEqual(testIndex, -1, "CI must run tests");
+  assert.ok(
+    installIndex < imageCacheIndex && imageCacheIndex < testIndex,
+    "the Astro image cache must be restored after npm ci and before npm test",
+  );
+});
 
 test("format verification rejects an unformatted fixture", (testContext) => {
   const temporaryDirectory = mkdtempSync(


### PR DESCRIPTION
## Summary
- restore Astro’s `node_modules/.astro` image cache after `npm ci`
- key the cache on dependencies, Astro configuration, components, and source images
- add regression coverage for cache restoration ordering

## Testing
- `npm test`
- `npx prettier --check .github/workflows/ci.yml test/ci-stages.test.mjs`