### PR TITLE
Cache Astro images in Lighthouse CI

### DIFF
--- a/.github/workflows/lighthouse-pull-request.yml
+++ b/.github/workflows/lighthouse-pull-request.yml
@@ -36,6 +36,22 @@ jobs:
           LIGHTHOUSE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node scripts/plan-lighthouse-pull-request.mjs
 
+      - name: Install base revision dependencies
+        if: steps.pull_request_plan.outputs.selected == 'true'
+        working-directory: .lighthouse-base
+        run: npm ci
+
+      - name: Restore Astro image caches
+        if: steps.pull_request_plan.outputs.selected == 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            node_modules/.astro
+            .lighthouse-base/node_modules/.astro
+          key: ${{ runner.os }}-astro-images-${{ hashFiles('package-lock.json', 'astro.config.mjs', 'src/**/*.astro', 'src/**/*.avif', 'src/**/*.gif', 'src/**/*.jpeg', 'src/**/*.jpg', 'src/**/*.png', 'src/**/*.webp', '.lighthouse-base/package-lock.json', '.lighthouse-base/astro.config.mjs', '.lighthouse-base/src/**/*.astro', '.lighthouse-base/src/**/*.avif', '.lighthouse-base/src/**/*.gif', '.lighthouse-base/src/**/*.jpeg', '.lighthouse-base/src/**/*.jpg', '.lighthouse-base/src/**/*.png', '.lighthouse-base/src/**/*.webp') }}
+          restore-keys: |
+            ${{ runner.os }}-astro-images-
+
       - name: Build pull-request revisions
         if: steps.pull_request_plan.outputs.selected == 'true'
         env:
@@ -44,7 +60,6 @@ jobs:
           npm run build
           (npm run preview -- --host 127.0.0.1 --port 4321 > "$RUNNER_TEMP/lighthouse-head.log" 2>&1 &)
           cd .lighthouse-base
-          npm ci
           if grep -q LIGHTHOUSE_PREVIEW_SLUGS src/lib/essays.ts; then
             npm run build
           else

--- a/test/lighthouse-workflow.test.mjs
+++ b/test/lighthouse-workflow.test.mjs
@@ -89,6 +89,32 @@ test("pull-request revisions are isolated and measured on one unprivileged runne
   );
 });
 
+test("pull-request builds restore Astro image caches after dependency installation", () => {
+  const headInstallIndex = pullRequestWorkflow.indexOf("- run: npm ci");
+  const baseInstallIndex = pullRequestWorkflow.indexOf(
+    "working-directory: .lighthouse-base",
+  );
+  const imageCacheIndex = pullRequestWorkflow.indexOf(
+    "name: Restore Astro image caches",
+  );
+  const buildIndex = pullRequestWorkflow.indexOf(
+    "name: Build pull-request revisions",
+  );
+
+  assert.notEqual(headInstallIndex, -1, "the head revision must be installed");
+  assert.notEqual(baseInstallIndex, -1, "the base revision must be installed");
+  assert.notEqual(imageCacheIndex, -1, "Astro image caches must be restored");
+  assert.notEqual(buildIndex, -1, "the revisions must be built");
+  assert.match(pullRequestWorkflow, /path: \|\n\s+node_modules\/\.astro/);
+  assert.match(pullRequestWorkflow, /\.lighthouse-base\/node_modules\/\.astro/);
+  assert.ok(
+    headInstallIndex < imageCacheIndex &&
+      baseInstallIndex < imageCacheIndex &&
+      imageCacheIndex < buildIndex,
+    "both Astro image caches must be restored after npm ci and before the builds",
+  );
+});
+
 test("scheduled reruns retain one durable observation identity", () => {
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary
- restore Astro image caches for both pull-request revisions
- install base dependencies before restoring its cache
- add a regression test for install/cache/build ordering

## Validation
- `npm test` (219 tests)
- `npx prettier --check .github/workflows/lighthouse-pull-request.yml test/lighthouse-workflow.test.mjs`
- `git diff --check`