### PR TITLE
Make publication delivery resilient

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
         with:

--- a/scripts/orchestrate-publication.mjs
+++ b/scripts/orchestrate-publication.mjs
@@ -148,7 +148,6 @@ const kitPayload = (essay, coverUrl, sendAt, emailTemplateId) => ({
   published_at: essay.publishedAt.toISOString(),
   send_at: sendAt?.toISOString() ?? null,
   preview_text: newsletterParagraphs(essay.newsletterIntro)[0].slice(0, 150),
-  subscriber_filter: [{ all: [{ type: "all_subscribers" }] }],
   thumbnail_alt: essay.coverAlt,
   thumbnail_url: coverUrl,
   ...(emailTemplateId ? { email_template_id: emailTemplateId } : {}),

--- a/src/lib/publication-orchestrator.mjs
+++ b/src/lib/publication-orchestrator.mjs
@@ -1,4 +1,4 @@
-const DEFAULT_POLL_ATTEMPTS = 10;
+const DEFAULT_POLL_ATTEMPTS = 24;
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 
 const completedHash = (publicationState, slug) =>

--- a/test/publication-orchestrator.test.mjs
+++ b/test/publication-orchestrator.test.mjs
@@ -124,6 +124,8 @@ test("Kit drafts and delivers the exact recorded broadcast with structured safe 
     /buthonestly-publication:safe-content/,
   );
   assert.equal(draftPayload.send_at, null);
+  assert.equal(draftPayload.subscriber_filter, undefined);
+  assert.equal(deliveryPayload.subscriber_filter, undefined);
   assert.equal(deliveryPayload.send_at, "2026-09-15T13:15:00.000Z");
   assert.match(draftPayload.content, /First &lt;paragraph&gt; &amp; safe\./);
   assert.match(draftPayload.content, /Second paragraph\./);
@@ -685,6 +687,24 @@ test("a missing production version stays pending when deployment polling times o
   });
 });
 
+test("the default deployment wait covers 12 minutes", async () => {
+  const slow = essay("slow");
+  const { ports, calls } = createHarness({
+    now: new Date("2026-09-16T00:00:00.000Z"),
+    essays: [slow],
+    productionVersions: {
+      slow: [...Array(24).fill("old-production"), slow.publicContentHash],
+    },
+  });
+
+  const result = await runPublication(ports);
+
+  assert.equal(calls.deployments, 1);
+  assert.equal(calls.sleeps.length, 24);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.submitted, [slow.slug]);
+});
+
 test("an unrecorded Kit draft is reconciled and persisted instead of duplicated", async () => {
   const candidate = essay("reconciled", {
     newsletterIntro: "A newsletter introduction.",
@@ -1058,6 +1078,7 @@ test("the publication workflow owns hourly, essay-change, and manual orchestrati
   assert.doesNotMatch(workflow, /GIT_SSH_COMMAND|ssh-key:/);
   assert.match(workflow, /group: publication/);
   assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /timeout-minutes: 30/);
   assert.equal(workflow.match(/run: npm run publication/g)?.length, 2);
   assert.match(workflow, /KIT_API_KEY/);
   assert.match(workflow, /Record draft identities and partial successes/);


### PR DESCRIPTION
## Summary
- allow Cloudflare Pages deployments up to 12 minutes to become live
- extend the publication job timeout so checkpoint and resume phases retain enough time
- omit Kit's rejected all-subscribers filter and rely on its documented default
- cover the deployment window and Kit payload with regression tests

## Validation
- `npm test`
- `node --test test/publication-orchestrator.test.mjs`
